### PR TITLE
feat: provide a default value for summary key during plugins bootstrap

### DIFF
--- a/adm/templates/plugins/archive/cookiecutter.json
+++ b/adm/templates/plugins/archive/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "name": "name_of_your_plugin",
     "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
-    "one_line_summary": "",
+    "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",
     "vendor": "MetWork",

--- a/adm/templates/plugins/default/cookiecutter.json
+++ b/adm/templates/plugins/default/cookiecutter.json
@@ -2,7 +2,7 @@
     "python_version": ["python3", "python2"],
     "name": "name_of_your_plugin",
     "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
-    "one_line_summary": "",
+    "one_line_summary": "one line summary about your plugin",
     "crontab_support": ["no", "yes"],
     "virtualenv_support": ["no", "yes"],
     "license": ["Proprietary", "BSD", "MIT", "GPL", "Specific"],

--- a/adm/templates/plugins/delete/cookiecutter.json
+++ b/adm/templates/plugins/delete/cookiecutter.json
@@ -1,11 +1,10 @@
 {
     "name": "name_of_your_plugin",
     "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
-    "one_line_summary": "",
+    "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",
     "vendor": "MetWork",
     "directory": "",
     "switch_logical_condition": "False"
 }
-

--- a/adm/templates/plugins/fork/cookiecutter.json
+++ b/adm/templates/plugins/fork/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "name": "name_of_your_plugin",
     "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
-    "one_line_summary": "",
+    "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",
     "vendor": "MetWork",

--- a/adm/templates/plugins/ftpsend/cookiecutter.json
+++ b/adm/templates/plugins/ftpsend/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "name": "name_of_your_plugin",
     "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
-    "one_line_summary": "",
+    "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",
     "vendor": "MetWork",
@@ -17,4 +17,3 @@
     "reinject_attempts": "5",
     "switch_logical_condition": "False"
 }
-

--- a/adm/templates/plugins/move/cookiecutter.json
+++ b/adm/templates/plugins/move/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "name": "name_of_your_plugin",
     "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
-    "one_line_summary": "",
+    "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",
     "vendor": "MetWork",


### PR DESCRIPTION
Because we can't build a plugin with an empty summary.