### PR TITLE
[WIP] feat: Changes in management of layer dependencies and metapackage names

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ pipeline:
       - /buildcache:/buildcache
     when:
       event: push
-      branch: [ master, release_* ]
+      branch: [ master, experimental*, release_* ]
   bootstrap_tag:
     image: metwork/mfxxx-${OS_VERSION}-buildimage:${DRONE_BRANCH}
     environment:
@@ -109,7 +109,7 @@ pipeline:
       - TARGET_DIR=${DRONE_BRANCH##release_}
     when:
       event: push
-      branch: [ master, release_* ]
+      branch: [ master, experimental*, release_* ]
   build_tag:
     <<: *build_common
     image: metwork/mfxxx-${OS_VERSION}-buildimage:${DRONE_BRANCH}
@@ -129,7 +129,7 @@ pipeline:
     image: metwork/mfxxx-${OS_VERSION}-buildimage:${DRONE_BRANCH}
     when:
       event: push
-      branch: [ master, release_* ]
+      branch: [ master, experimental*, release_* ]
   publish_tag:
     image: metwork/mfxxx-${OS_VERSION}-buildimage:${DRONE_BRANCH}
     volumes:
@@ -157,7 +157,7 @@ pipeline:
     when:
       status: [ success ]
       event: push
-      branch: [ master, integration, release_* ]
+      branch: [ master, integration, experimental*, release_* ]
 
 
 
@@ -166,4 +166,4 @@ matrix:
     - centos6
     - centos7
 
-branches: [ master, integration, ci_*, pci_*, release_* ]
+branches: [ master, integration, experimental*, ci_*, pci_*, release_* ]

--- a/.layerapi2_dependencies
+++ b/.layerapi2_dependencies
@@ -1,0 +1,4 @@
+root@mfcom
+#+python3_circus@mfext
+openresty@mfext
+#+rpm@mfext

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ MODULE_LOWERCASE=mfdata
 DIRS=config bin opt/python2/lib/python$(PYTHON2_SHORT_VERSION)/site-packages opt/python3/lib/python$(PYTHON3_SHORT_VERSION)/site-packages share
 
 all:: directories
-	echo "root@mfcom" >$(MFDATA_HOME)/.layerapi2_dependencies
-	echo "openresty@mfext" >>$(MFDATA_HOME)/.layerapi2_dependencies
 	cd adm && $(MAKE)
 	cd config && $(MAKE)
 	cd layers && $(MAKE)

--- a/layers/layer1_python2/.layerapi2_dependencies
+++ b/layers/layer1_python2/.layerapi2_dependencies
@@ -1,2 +1,1 @@
 python2@mfcom
-root@mfdata

--- a/layers/layer1_python3/.layerapi2_dependencies
+++ b/layers/layer1_python3/.layerapi2_dependencies
@@ -1,2 +1,1 @@
-root@mfdata
 python3@mfcom

--- a/layers/layer9_default/.layerapi2_dependencies
+++ b/layers/layer9_default/.layerapi2_dependencies
@@ -1,0 +1,3 @@
+root@mfdata
+python@mfdata
+default@mfcom

--- a/layers/layer9_default/.layerapi2_label
+++ b/layers/layer9_default/.layerapi2_label
@@ -1,0 +1,1 @@
+default@mfdata

--- a/layers/layer9_default/Makefile
+++ b/layers/layer9_default/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk

--- a/layers/layer9_python/.layerapi2_dependencies
+++ b/layers/layer9_python/.layerapi2_dependencies
@@ -1,0 +1,2 @@
+python@mfcom
+python{METWORK_PYTHON_MODE}@mfdata

--- a/layers/layer9_python/.layerapi2_label
+++ b/layers/layer9_python/.layerapi2_label
@@ -1,0 +1,1 @@
+python@mfdata

--- a/layers/layer9_python/Makefile
+++ b/layers/layer9_python/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk


### PR DESCRIPTION
(only minimal and full)
Associated with changes in mfext _metwork.spec, this reduces the number of layers installed by default when installing mfdata (only necessary mfext layers are installed)
Metapackage metwork-mfdata-minimal only installs the necessary layers for mfdata to work properly
Metapackage metwork-mfdata or metwork-mfserv-full installs all mfdata layers

linked to #26 (mfdata part)