### PR TITLE
fix: dump tags on errors (when in debug mode)

### DIFF
--- a/layers/layer1_python3/0300_acquisition/acquisition/step.py
+++ b/layers/layer1_python3/0300_acquisition/acquisition/step.py
@@ -150,10 +150,9 @@ class AcquisitionStep(object):
         if not after_status:
             self.warning("Bad processing status for file: %s",
                          xaf._original_filepath)
-            # logger = self.__get_logger()
-            # FIXME: waiting for metwork-framework/mflog#1
-            # if logger.isEnabledFor(10):  # DEBUG
-            # xaf.dump_tags_on_logger(logger, 10)  # DEBUG
+            logger = self.__get_logger()
+            if logger.isEnabledFor(10):  # DEBUG
+                xaf.dump_tags_on_logger(logger, 10)  # DEBUG
         return after_status
 
     def _conditional_copy_to_debug_plugin(self, xaf):


### PR DESCRIPTION
thanks to a mflog change