### PR TITLE
feat: fix #65 and introduce new configuration options around

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -112,9 +112,9 @@ workers=@@@MFCOM_HARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2@@@
 logging=1
 
 
-###################
-##### PLUGINS #####
-###################
+############################
+##### INTERNAL PLUGINS #####
+############################
 [internal_plugins]
 install_switch=1
 install_ungzip=0
@@ -131,6 +131,14 @@ switch_no_match_policy=delete
 
 # if switch_no_match_policy = move, set the destination directory
 switch_no_match_move_policy_dest_dir=/dev/null
+
+# if switch_no_match_policy = keep, you can choose to keep attributes/tags
+# in another file (if the value is 1) or not (the value is 0)
+switch_no_match_keep_policy_keep_tags=1
+
+# if switch_no_match_policy = keep and switch_no_match_keep_policy_keep_tags=1
+# you can set the suffix used to store attributes/tags
+switch_no_match_keep_policy_keep_tags_suffix=.tags
 
 
 ####################

--- a/plugins/switch/config.ini
+++ b/plugins/switch/config.ini
@@ -36,7 +36,7 @@ cmd = {{MFDATA_CURRENT_PLUGIN_DIR}}/main.py
 # Arguments for the cmd
 # (if you use the standard Acquisition framework, you can alse set some options
 #  with the following arg_{key} keys)
-args = --config-file={{MFDATA_CURRENT_CONFIG_INI_PATH}} --no-match-policy={{MFDATA_INTERNAL_PLUGINS_SWITCH_NO_MATCH_POLICY}} --no-match-policy-move-dest-dir={{MFDATA_INTERNAL_PLUGINS_SWITCH_NO_MATCH_MOVE_POLICY_DEST_DIR}} {{MFDATA_CURRENT_STEP_QUEUE}}
+args = --config-file={{MFDATA_CURRENT_CONFIG_INI_PATH}} --no-match-policy={{MFDATA_INTERNAL_PLUGINS_SWITCH_NO_MATCH_POLICY}} {% if MFDATA_INTERNAL_PLUGINS_SWITCH_NO_MATCH_POLICY == "move" %}--no-match-policy-move-dest-dir={{MFDATA_INTERNAL_PLUGINS_SWITCH_NO_MATCH_MOVE_POLICY_DEST_DIR}}{% endif %} {% if MFDATA_INTERNAL_PLUGINS_SWITCH_NO_MATCH_POLICY == "keep" %}{% if MFDATA_INTERNAL_PLUGINS_SWITCH_NO_MATCH_KEEP_POLICY_KEEP_TAGS == "1" %}--no-match-policy-keep-keep-tags --no-match-policy-keep-keep-tags-suffix={{MFDATA_INTERNAL_PLUGINS_SWITCH_NO_MATCH_KEEP_POLICY_KEEP_TAGS_SUFFIX}}{% endif %}{% endif %} {{MFDATA_CURRENT_STEP_QUEUE}}
 
 # Extra arguments on the arg_{key} template, will be used as default value
 # for CLI parsing if you use the standard Acquisition framework.


### PR DESCRIPTION
Now (and it is on by default), we can dump tags into another file
(like with archive plugins) when moving the file to the trash.

Close #65