### PR TITLE
docs: Update MFDATA documentation + add "Edit on GitHub"

### DIFF
--- a/.metwork-framework/plugins_guide.md
+++ b/.metwork-framework/plugins_guide.md
@@ -1,38 +1,83 @@
 # Plugins guide
 
-## Commands
+## Plugins Configuration
+A plugin has its own configuration in `config.ini` file stored in the root directory of the plugin (`${MODULE_RUNTIME_HOME}`).
+
+This `config.ini` file is created with its requisite configuration during the `bootstrap_plugin.py create` command.
+
+You can change some of the configuration parameters and/or add configuration specific to your plugin.
+
+Every time you change the configuration file, you have to stop and start the Metwork module to reload the configuration, by entering the commands :
+
+- either
+```bash
+{MODULE_RUNTIME_HOME}.stop
+{MODULE_RUNTIME_HOME}.start
+```
+- or (as root user)
+```bash
+service metwork restart {MODULE_RUNTIME_HOME}
+```
+
+with {MODULE_RUNTIME_HOME} the Metwork module you are working with, e.g. mfdata.
+
+The configuration parameters are described and explained in the `${MODULE_RUNTIME_HOME}/config/config.ini` file.
+
+## Plugins Commands
+
+This section sums up all the commands you will need to build, install a plugin.
+
+Use `-h` or `--help` option of the command to review all available options of the command.
 
 ### `plugins.list`
 
 List installed plugins.
+```bash
+plugins.list [options]
+```
 
 Note: if you have a version named `dev_link`, the plugin is installed as a symbolic link to a source directory. 
 It's a kind of "development mode".
 
+
 ### `plugins.install`
 
-Install a given plugin (`.plugin`) file.
+Install a given plugin from a `.plugin` file.
+```bash
+plugins.install {plugin file path} [options]
+```
 
 ### `plugins.uninstall`
 
 Uninstall a given plugin **name** (not file). The name corresponds to the first column of `plugins.list` output.
+```bash
+plugins.uninstall {plugin name} [options]
+```
+
+### `plugins.info`
+
+Get more infomation about a  plugin.
+```bash
+plugins.info {plugin_name}
+```
 
 ### `plugin_env`
 
-If you have a virtualenv in your plugin or if you want to simulate the exact environment your code will run in the context
-of your plugin, you can use the `plugin_env` interactive command.
+If you have a virtualenv in your plugin or if you want to simulate the exact environment your code will run in the context of your plugin, you can use the `plugin_env` interactive command.
 
 If you are developping, the best way is to go in the root directory of your plugin and use `plugin_env` without argument.
 
 If you have a "normal" installed plugin, you can use `plugin_env {PLUGIN_NAME}`.
 
 When you are inside a plugin environment, you will find some extra environment variables:
+```bash
+env | grep "^${MODULE}_" | grep CURRENT
+```
 
 ```
-# Example with MFSERV, but it's the same idea with MFDATA or MFBASE
-MFSERV_CURRENT_PLUGIN_NAME=dashboard
-MFSERV_CURRENT_PLUGIN_DIR=/home/mfserv/var/plugins/dashboard
-MFSERV_CURRENT_PLUGIN_LABEL=plugin_dashboard@mfserv
+MFDATA_CURRENT_PLUGIN_NAME=my_plugin
+MFDATA_CURRENT_PLUGIN_DIR=/home/mfdata/var/plugins/my_plugin
+MFDATA_CURRENT_PLUGIN_LABEL=plugin_my_plugin@mfdata
 ```
 
 And of course, paths of your plugin "layer" (kind of virtualenv generalization) are loaded before system paths.
@@ -41,49 +86,132 @@ And of course, paths of your plugin "layer" (kind of virtualenv generalization) 
 
 This command follows the same idea than `plugin_env` but in a non-interactive way. Use it for example for `crontabs` or if you want to execute a command in a given plugin environment without changing anything to the current shell.
 
-```
+```bash
 plugin_wrapper {PLUGIN_NAME} {COMMAND} [{COMMAND_ARG1}] [{COMMAND_ARG2}] [...]
 ```
 
-Note: the plugin must be installed
+Note: the plugin {PLUGIN_NAME} must be installed.
 
-### Inside your plugin env
+## Make Commands
 
-#### make develop
+### make develop
 
 Install your plugin in "development mode" (you don't need to release and install each time you make a modification), the plugin installed through a symlink.
+```bash
+make develop
+```
 
-#### make release
+### make release
 
-Release your plugin as a ".plugin" file.
+Release your plugin as a `.plugin` file.
+```bash
+make release
+```
 
-#### make clean
+### make clean
 
 Clean (before release)
+```bash
+make clean
+```
 
-#### make superclean
+### make superclean
 
 Hard-clean, can be useful when you have error with your virtualenv
+```bash
+make superclean
+```
 
-#### make
+### make
 
 Build your virtualenv from sources
+```bash
+make
+```
+## Python virtualenv
 
-#### python3_virtualenv_sources/requirements-to-freeze.txt
+When developing Python applications, it’s standard practice to have a `requirements.txt` file.
 
-Add you python3 dependencies inside this file
+This file can be used in different ways, and typically takes one of these two forms:
 
-FIXME: explain requirements3.txt and the differences with requirements-to-freeze.txt and how the freeze of versions
-is managed
+- Simple requirements: A list of top-level dependencies a plugin has, often without versions specified.
+- Exact requirements: A complete list of all dependencies a plugin has, each with exact versions specified.
 
-#### python2_virtualenv_sources/requirements-to-freeze.txt
+### The 'Simple' requirements
 
-Add you python2 dependencies inside this file
+A list of **top-level dependencies** a plugin has, often without versions specified.
 
-FIXME: explain requirements3.txt and the differences with requirements-to-freeze.txt and how the freeze of versions
-is managed
+The `requirements.txt` looks like:
+```cfg
+requests[security]
+flask
+gunicorn==19.4.5
+```
+When a `requirements.txt` file like above is used to deploy in production environment, unexpected consequences can occur. Effectively, because versions haven’t been pinned, running `pip install` will give you different results today than it will tomorrow.
 
-#### FIXME/nodejs 
+This is rather a bad way. As different versions of sub-dependencies are released, the result of a fresh `pip install -r requirements.txt` will result in different packages being installed, and potentially, your application failing for unknown and hidden reasons.
+
+### The 'Exact' Requirements
+
+A complete list of **all dependencies** a plugin has, each with exact package versions specified.
+
+The `requirements.txt` looks like:
+```cfg
+cffi==1.5.2
+cryptography==1.2.2
+enum34==1.1.2
+Flask==0.10.1
+gunicorn==19.4.5
+idna==2.0
+ipaddress==1.0.16
+itsdangerous==0.24
+Jinja2==2.8
+MarkupSafe==0.23
+ndg-httpsclient==0.4.0
+pyasn1==0.1.9
+pycparser==2.14
+pyOpenSSL==0.15.1
+requests==2.9.1
+six==1.10.0
+Werkzeug==0.11.4
+```
+
+This is a best-practice for deploying applications, and ensures an explicit runtime environment with deterministic builds.
+
+All dependencies, including sub-dependencies, are listed, each with an exact version specified.
+
+While the this method for requirements.txt is best practice, it is a bit cumbersome. Namely, if you want to upgrade some or all of the packages, it's not so easy to do.
+
+### The 'Best' Requirements
+
+The best an simple way is to have two requirements file instead of having one:
+
+- requirements-to-freeze.txt
+- requirements.txt
+
+
+The `requirements-to-freeze.txt` uses 'simple' requirements', and is used to specify the top-level dependencies, and any explicit versions you need to specify.
+
+the `requirements.txt` uses 'exact' requirements, and contains the output of a `pip freeze` after `pip install requirements-to-freeze.txt` has been run.
+
+Working with Metwork plugin, you just need to fill the `requirements-to-freeze.txt` file. Then, when building/releasing the plugin, the `requirements.txt` will be generated.
+
+Depending of the Python
+Depending on which python version (python2 or python3) you are working with, the `requirements.txt` file will be named, respectively  `requirementsé.txt` and `requirements3.txt`
+
+### Python3 requirements-to-freeze.txt
+
+If you are working with python3, an empty `requirements-to-freeze.txt` is created in the `python3_virtualenv_sources` plugin directory (during the `bootstrap_plugin.py create` command)
+
+Add your python3 dependencies inside this file (with or without package version)
+
+
+### Python2 requirements-to-freeze.txt
+
+If you are working with python2, an empty `requirements-to-freeze.txt` is created in the `python2_virtualenv_sources` plugin directory (during the `bootstrap_plugin.py` create command)
+
+Add your python2 dependencies inside this file (with or without package version)
+
 
 
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,6 +21,7 @@ help:
 %.rst: %.md
 	rm -f tempo.md
 	echo ".. GENERATED FILE, DO NOT EDIT (edit $< instead)" >tempo.md
+	echo ":original_file: $<" >>tempo.md
 	echo >>tempo.md
 	cat $< |envtpl >>tempo.md
 	layer_wrapper --layers=python3_devtools@mfext -- m2r --overwrite tempo.md

--- a/doc/_templates/breadcrumbs.html
+++ b/doc/_templates/breadcrumbs.html
@@ -1,0 +1,38 @@
+{% extends "!breadcrumbs.html" %}
+    {% block breadcrumbs_aside %}
+      <li class="wy-breadcrumbs-aside">
+        {% if hasdoc(pagename) %}
+            {% if display_github %}
+            {% if check_meta and 'github_url' in meta %}
+              <!-- User defined GitHub URL -->
+              <a href="{{ meta['github_url'] }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+            {% else %}
+              {% if check_meta and 'original_file' in meta %}
+                <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ meta['original_file'] }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+              {% else %}
+                <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+              {% endif %}
+            {% endif %}
+          {% elif display_bitbucket %}
+            {% if check_meta and 'bitbucket_url' in meta %}
+              <!-- User defined Bitbucket URL -->
+              <a href="{{ meta['bitbucket_url'] }}" class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
+            {% else %}
+              <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ suffix }}?mode={{ theme_vcs_pageview_mode|default("view") }}" class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
+            {% endif %}
+          {% elif display_gitlab %}
+            {% if check_meta and 'gitlab_url' in meta %}
+              <!-- User defined GitLab URL -->
+              <a href="{{ meta['gitlab_url'] }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
+            {% else %}
+              <a href="https://{{ gitlab_host|default("gitlab.com") }}/{{ gitlab_user }}/{{ gitlab_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ gitlab_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
+            {% endif %}
+          {% elif show_source and source_url_prefix %}
+            <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">{{ _('View page source') }}</a>
+          {% elif show_source and has_source and sourcename %}
+            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>
+          {% endif %}
+        {% endif %}
+      </li>
+    {% endblock %}
+

--- a/doc/api_xattrfile.rst
+++ b/doc/api_xattrfile.rst
@@ -5,3 +5,8 @@ XATTRFILE API
 .. automodapi:: xattrfile
    :include-all-objects:
 
+.. automodapi:: xattrfile.print_tags
+
+.. automodapi:: xattrfile.get_tag
+
+.. automodapi:: xattrfile.set_tag

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,10 +18,38 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',
               'sphinx.ext.intersphinx',
+              'sphinx.ext.autosectionlabel',
               'sphinx_automodapi.automodapi',
               'sphinx_automodapi.smart_resolver',
               ]
 
+# A dictionary of values to pass into the template engine’s context for all pages
+html_context = {
+    # Enable the "Edit in GitHub link within the header of each page. See https://docs.readthedocs.io/en/stable/vcs.html
+    'display_github': True,
+    # Set the following variables to generate the resulting github URL for each page.
+    'github_user': 'metwork-framework',
+    'github_repo': 'mfdata',
+    'github_version': 'integration',
+    # Path in the checkout to the docs root
+    'conf_py_path': '/doc/',
+    # Changes how to view files when using display_github, display_gitlab, etc.
+    # When using GitHub or GitLab this can be: blob (default), edit, or raw.
+    # See https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html#confval-vcs_pageview_mode
+    # Warning : the parameter is theme_vcs_pageview_mode and not vcs_pageview_mode as mentionned in the the documentation
+    'theme_vcs_pageview_mode': 'edit'
+}
+
+
+# True to prefix each section label with the name of the document it is in,
+# followed by a colon. For example, index:Introduction for a section called Introduction that appears in document index.rst.
+# Useful for avoiding ambiguity when the same section heading appears in different documents.
+autosectionlabel_prefix_document = True
+
+# If set, autosectionlabel chooses the sections for labeling by its depth.
+# For example, when set 1 to autosectionlabel_maxdepth, labels are generated only for top level sections,
+# and deeper sections are not labeled. It defaults to None (disabled).
+autosectionlabel_maxdepth = 3
 
 # The output format for Graphviz when building HTML files. This must be either 'png' or 'svg'
 graphviz_output_format = 'svg'

--- a/doc/mfdata_additional_tutorials.md
+++ b/doc/mfdata_additional_tutorials.md
@@ -583,7 +583,7 @@ grib_to_netcdf_options=-k 3 -d 0 -D NC_FLOAT
 Each parameter will be will transform into an environment variable whose pattern is `{MODULE}_{SECTION_NAME}_{PARAMETER_NAME}`, e.g. `MFDATA_PLUGIN_CONVERT_GRIB2_GRIB_TO_NETCDF_OPTIONS`
 
 **CAUTION**:
-- Enviroment variable are always in uppercase.
+- Enviroment variables are always in uppercase.
 - To get the new value, you have to close/reopen your terminal to force a new profile loading.
 - To change daemons and services behaviour (like `nginx` listening port in your example), you have to restart services from a newly restarted terminal or from a `root` user through `service metwork restart` command.
 

--- a/doc/mfdata_create_plugins.md
+++ b/doc/mfdata_create_plugins.md
@@ -22,7 +22,7 @@ The syntax to set argument in the `mfdata/{PLUGIN_NAME}/config.ini` file is of t
 
 One of the most crucial field for your plugin is `switch_logical_condition`: **it represents the condition that must be respected so the switch directs the data to your plugin**.
 
-In other words, it represents what kind of data will be orientated towards your plugin by the `switch` plugin. For example, this is where you would put that you want `.jpg` files to be treated by a plugin. In the same example, this would translate as `( x['latest.switch.main.system_magic'].startswith(b'JPEG image') )`. The condition is written in Python and is `None` by default. **This condition must be a boolean expression that evaluates as** `True` **for the type of data you are interested in**.
+In other words, it represents what kind of data will be orientated towards your plugin by the `switch` plugin. For example, this is where you would put that you want `.jpg` files to be treated by a plugin. In the same example, this would translate as `( x['latest.switch.main.system_magic'].startswith(b'JPEG image') )`. The condition is written in Python and is `False` by default. **This condition must be a boolean expression that evaluates as** `True` **for the type of data you are interested in**.
 
 
 **If the templates don't satisfy your needs, you can always edit the generated** `main.py` **file** in your plugin's directory. This file inherits from a certain class depending on the template you chose during the creation of the plugin (if you chose a template). From your `main.py` file, you can override any method to suit your needs. For further about the role of each method, check :doc:`../api_acquisition` documentation.

--- a/doc/mfdata_deploy_plugin.md
+++ b/doc/mfdata_deploy_plugin.md
@@ -52,7 +52,7 @@ plugins.list
 In practice, the plugins are installed in the `~/var/plugins` directory.
 
 
-### The 'workmanlike' way
+### The 'well-done' way
 
 ** This is the recommended way to deploy a plugin in a production environment**
 

--- a/doc/mfdata_miscellaneous.md
+++ b/doc/mfdata_miscellaneous.md
@@ -3,15 +3,55 @@
 
 ## The `switch_logical_condition` field
 
-TODO
+The `switch_logical_condition` is a plugin configuration field of the `config.ini` file in the rrot directory of the plugin.
+
+The `switch_logical_condition`  **represents the condition that must be respected so the** `switch` ** plugin directs the data to the plugin**. 
+
+
+When you create a plugin through the `bootstrap_plugin create` command, the default value is set to `False` (that means no file will be processed by the plugin).
+
+`switch_logical_condition = False` means the `switch` plugin doesn't redirect any file to the plugin.
+
+`switch_logical_condition = True` means the `switch` plugin redirects all files to the plugin.
+
+`switch_logical_condition = {condition}` means the `switch` plugin redirects the file to the plugin if the `{condition}` is `True`. 
+
+In most cases, the `{condition}` is based  on tags attributes set by the `switch` plugin.
+
+The main useful tags are: `first.core.original_basename` (the base name of the processed file), `latest.switch.main.system_magic`
+`latest.switch.main.{plugin name}_magic` (the 'magic' file. See :doc:`./mfdata_and_magic`).
+
 
 ## The `switch` plugin tags attributes
 
-TODO
+The `switch` plugin sets some tags attributes.
+
+Attributes are stored inside an :py:class:`XattrFile <xattrfile.XattrFile>` object.
+
+These tags trace the flows processed by the different plugins and gives information about processed files.
+
+If you need to set your own tags, refer to :py:meth:`write_tags_in_a_file <xattrfile.XattrFile.write_tags_in_a_file>`, :py:meth:`print_tags <xattrfile.print_tags>`, :py:meth:`set_tag <xattrfile.set_tag>`, :py:meth:`get_tag <xattrfile.get_tag>`
+
+You may also check the :ref:`mfdata_additional_tutorials:Fill in the plugin` section of  :doc:`./mfdata_additional_tutorials`.
 
 ## Inject data files in HTTP
 
-TODO - curl examples 
+MFDATA allows to inject files through HTTP protocol.
+
+By default a Nginx HTTP server is listening on port `9091`.
+
+The HTTP url to post your files is `http://{your_mfdata_host_name}:9091/incoming/` (`http://{your_mfdata_host_name}:9091/` works too).
+
+Only HTTP **PUT** and **POST** methods are allowed.
+
+Here is a example to inject data with curl [curl](https://curl.haxx.se/docs/manpage.html):
+```bash
+curl -v -X POST -d @{your file path} http://localhost:9091/incoming/
+```
+
+You may change some configuration fields of the nginx server (including the port) in the `[nginx]` section of the `/home/mfdata/config/config.ini` file.
+
+For a more detailed description of nginx configuration, check the  `/home/mfdata/config/config.ini` file.
 
 ## Plugins with more than one step
 

--- a/layers/layer1_python3/0200_xattrfile/xattrfile/get_tag.py
+++ b/layers/layer1_python3/0200_xattrfile/xattrfile/get_tag.py
@@ -5,6 +5,9 @@ DESCRIPTION = "get an attribute on a given file"
 
 
 def main():
+    """
+    Get an attribute on a given file
+    """
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser.add_argument('filepath',
                         help='Path of the file of which you want to print tags'

--- a/layers/layer1_python3/0200_xattrfile/xattrfile/print_tags.py
+++ b/layers/layer1_python3/0200_xattrfile/xattrfile/print_tags.py
@@ -5,6 +5,9 @@ DESCRIPTION = "print attributes of the given file"
 
 
 def main():
+    """
+    Print attributes of the given file
+    """
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser.add_argument('filepath',
                         help='Path of the file of which you want to print tags'

--- a/layers/layer1_python3/0200_xattrfile/xattrfile/set_tag.py
+++ b/layers/layer1_python3/0200_xattrfile/xattrfile/set_tag.py
@@ -5,6 +5,9 @@ DESCRIPTION = "set an attribute on a given file"
 
 
 def main():
+    """
+    Set an attribute on a given file
+    """
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser.add_argument('filepath',
                         help='Path of the file of which you want to print tags'


### PR DESCRIPTION
- Update MFDATA doc
- Add missing docstring to APIs
- Add sphinx.ext.autosectionlabel extension to be able to allow cross-reference sections using its title
- Add conf. + code to be able to add "Edit on GitHub", on the correct file (.md or rst depending on original source). "Edit on GitHub" acts on the 'integration" branch (not on master branch). See html_context in conf.py.

Note : actually plugins_guide.md is changed, but it will be overwrittent by the plugins_guide.md in the Metwork 'resources' repo. See https://github.com/metwork-framework/resources/pull/35 