### PR TITLE
feat: replace MODULE* environment variables names by MFMODULE* (MODUL…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MODULE=MFDATA
-MODULE_LOWERCASE=mfdata
+MFMODULE=MFDATA
+MFMODULE_LOWERCASE=mfdata
 
 -include adm/root.mk
 -include $(MFEXT_HOME)/share/main_root.mk

--- a/adm/_directory_observer.stop
+++ b/adm/_directory_observer.stop
@@ -8,8 +8,8 @@ import signal
 from mflog import getLogger
 
 LOG = getLogger('directory_observer.stop')
-USER = os.environ.get('MODULE_RUNTIME_USER', None)
-MODULE_RUNTIME_HOME = os.environ.get('MODULE_RUNTIME_HOME', None)
+USER = os.environ.get('MFMODULE_RUNTIME_USER', None)
+MFMODULE_RUNTIME_HOME = os.environ.get('MFMODULE_RUNTIME_HOME', None)
 
 
 def get_directory_observer_master_pids():
@@ -22,7 +22,7 @@ def get_directory_observer_master_pids():
             if 'directory_observer.directory_observer' not in cmdline:
                 continue
             cwd = proc.cwd()
-            if not cwd.startswith(MODULE_RUNTIME_HOME):
+            if not cwd.startswith(MFMODULE_RUNTIME_HOME):
                 continue
             pids.append(proc.pid)
         except Exception:

--- a/adm/_make_circus_conf
+++ b/adm/_make_circus_conf
@@ -6,9 +6,9 @@ import envtpl
 from configparser_extended import ExtendedConfigParser
 from acquisition.utils import _set_custom_environment
 
-MODULE_HOME = os.environ["MODULE_HOME"]
-MODULE_RUNTIME_HOME = os.environ["MODULE_RUNTIME_HOME"]
-MFDATA_PLUGIN_HOME = os.path.join(os.environ["MODULE_RUNTIME_HOME"],
+MFMODULE_HOME = os.environ["MFMODULE_HOME"]
+MFMODULE_RUNTIME_HOME = os.environ["MFMODULE_RUNTIME_HOME"]
+MFDATA_PLUGIN_HOME = os.path.join(os.environ["MFMODULE_RUNTIME_HOME"],
                                   "var", "plugins")
 CONFIG = os.environ.get('MFCONFIG', 'GENERIC')
 
@@ -67,11 +67,11 @@ def make_watcher_conf(plugin_configuration_file):
             rlimit_fsize = parser.getint(section, "rlimit_fsize")
         if numprocesses > 1:
             std_prefix = \
-                "{{MODULE_RUNTIME_HOME}}/log/step_%s_%s_worker$(circus.wid)" % \
+                "{{MFMODULE_RUNTIME_HOME}}/log/step_%s_%s_worker$(circus.wid)" % \
                 (plugin_name, step)
 
         else:
-            std_prefix = "{{MODULE_RUNTIME_HOME}}/log/step_%s_%s" % \
+            std_prefix = "{{MFMODULE_RUNTIME_HOME}}/log/step_%s_%s" % \
                 (plugin_name, step)
         stdout = std_prefix + ".stdout"
         stderr = std_prefix + ".stderr"
@@ -105,9 +105,9 @@ def make_watcher_conf(plugin_configuration_file):
         output.append("stdout_stream.class = FileStream")
         output.append("stderr_stream.class = FileStream")
         output.append("stdout_stream.filename = "
-                      "{{MODULE_RUNTIME_HOME}}/log/circus.log")
+                      "{{MFMODULE_RUNTIME_HOME}}/log/circus.log")
         output.append("stderr_stream.filename = "
-                      "{{MODULE_RUNTIME_HOME}}/log/circus.log")
+                      "{{MFMODULE_RUNTIME_HOME}}/log/circus.log")
         if before_start:
             output.append("hooks.before_start = %s" % before_start)
 
@@ -115,21 +115,21 @@ def make_watcher_conf(plugin_configuration_file):
         output.append("")
         output.append("[watcher:redis_service_for_plugin_%s]" % plugin_name)
         output.append("cmd = redis-server")
-        output.append("args = {{MODULE_RUNTIME_HOME}}/tmp/config_auto/"
+        output.append("args = {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/"
                       "redis_plugin_%s.conf" % plugin_name)
         output.append("numprocesses = 1")
         output.append("stdout_stream.class = FileStream")
-        output.append("stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/"
+        output.append("stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/"
                       "redis_plugin_%s.log" % plugin_name)
         output.append("stderr.class = FileStream")
-        output.append("stderr.filename = {{MODULE_RUNTIME_HOME}}/log/"
+        output.append("stderr.filename = {{MFMODULE_RUNTIME_HOME}}/log/"
                       "redis_plugin_%s.log" % plugin_name)
         output.append("copy_env = True")
         output.append("autostart = True")
         output.append("respawn = True")
         with open("%s/tmp/config_auto/redis_plugin_%s.conf" %
-                  (MODULE_RUNTIME_HOME, plugin_name), "w+") as f:
-            with open("%s/config/redis_plugin_xxx.conf" % MODULE_HOME,
+                  (MFMODULE_RUNTIME_HOME, plugin_name), "w+") as f:
+            with open("%s/config/redis_plugin_xxx.conf" % MFMODULE_HOME,
                       "r") as f2:
                 content = f2.read()
             new_content = envtpl.render_string(content,
@@ -153,11 +153,11 @@ def make_watcher_conf(plugin_configuration_file):
         output.append("autostart = True")
         output.append("respawn = True")
         output.append("stdout_stream.class = FileStream")
-        output.append("stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/"
+        output.append("stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/"
                       "extra_daemon_%s_plugin_%s.log" %
                       (extra_daemon, plugin_name))
         output.append("stderr.class = FileStream")
-        output.append("stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/"
+        output.append("stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/"
                       "extra_daemon_%s_plugin_%s.log" %
                       (extra_daemon, plugin_name))
         rlimit_as = None
@@ -194,7 +194,7 @@ def make_watcher_conf(plugin_configuration_file):
                                 keep_multi_blank_lines=False)
 
 
-circus_ini_file = os.path.join(os.environ['MODULE_HOME'], 'config',
+circus_ini_file = os.path.join(os.environ['MFMODULE_HOME'], 'config',
                                'circus.ini')
 with open(circus_ini_file, "r") as f:
     content = envtpl.render_string(f.read(), keep_multi_blank_lines=False)

--- a/adm/_make_directory_observer_conf
+++ b/adm/_make_directory_observer_conf
@@ -6,7 +6,7 @@ import envtpl
 from configparser_extended import ExtendedConfigParser
 from acquisition.utils import _set_custom_environment
 
-MFDATA_PLUGIN_HOME = os.path.join(os.environ["MODULE_RUNTIME_HOME"],
+MFDATA_PLUGIN_HOME = os.path.join(os.environ["MFMODULE_RUNTIME_HOME"],
                                   "var", "plugins")
 CONFIG = os.environ.get('MFCONFIG', 'GENERIC')
 
@@ -35,7 +35,7 @@ def make_directory_observer_conf(plugin_configuration_file):
         tmp_listened_directories = \
             tmp_listened_directories.replace('{{%s}}' % special_value,
                                              os.environ[special_value])
-        listened_directories = ["{{MODULE_RUNTIME_HOME}}/var/in/%s" % x.strip()
+        listened_directories = ["{{MFMODULE_RUNTIME_HOME}}/var/in/%s" % x.strip()
                                 for x in tmp_listened_directories.split(';')
                                 if "/" not in x]
         for i in range(0, len(listened_directories)):
@@ -51,7 +51,7 @@ def make_directory_observer_conf(plugin_configuration_file):
     return "\n".join(output)
 
 
-directory_observer_ini_file = os.path.join(os.environ['MODULE_HOME'], 'config',
+directory_observer_ini_file = os.path.join(os.environ['MFMODULE_HOME'], 'config',
                                            'directory_observer.ini')
 with open(directory_observer_ini_file, "r") as f:
     content = f.read()

--- a/adm/_make_nginx_conf
+++ b/adm/_make_nginx_conf
@@ -2,15 +2,15 @@
 
 set -eu
 
-TMPFILE="${MODULE_RUNTIME_HOME}/tmp/nginx_conf.$$"
+TMPFILE="${MFMODULE_RUNTIME_HOME}/tmp/nginx_conf.$$"
 
-UUID=$(cat "${MODULE_RUNTIME_HOME}/var/uuid" 2>/dev/null)
+UUID=$(cat "${MFMODULE_RUNTIME_HOME}/var/uuid" 2>/dev/null)
 if test "${UUID}" = ""; then
     UUID="unknown"
 fi
 export UUID
 
-cat "${MODULE_HOME}/config/nginx.conf" |envtpl --reduce-multi-blank-lines >"${TMPFILE}"
+cat "${MFMODULE_HOME}/config/nginx.conf" |envtpl --reduce-multi-blank-lines >"${TMPFILE}"
 nginxfmt.py "${TMPFILE}"
 # FIXME: ugly hack to circumvent nginxfmt problem with JSON
 cat -s "${TMPFILE}" |sed 's/~~~1/{/g' |sed 's/~~~2/}/g'

--- a/adm/_make_switch_conf
+++ b/adm/_make_switch_conf
@@ -5,7 +5,7 @@ import glob
 import envtpl
 from configparser_extended import ExtendedConfigParser
 
-MFDATA_PLUGIN_HOME = os.path.join(os.environ["MODULE_RUNTIME_HOME"],
+MFDATA_PLUGIN_HOME = os.path.join(os.environ["MFMODULE_RUNTIME_HOME"],
                                   "var", "plugins")
 CONFIG = os.environ.get('MFCONFIG', 'GENERIC')
 

--- a/adm/_switch.stop
+++ b/adm/_switch.stop
@@ -8,8 +8,8 @@ import signal
 from mflog import getLogger
 
 LOG = getLogger('switch.stop')
-USER = os.environ.get('MODULE_RUNTIME_USER', None)
-MODULE_RUNTIME_HOME = os.environ.get('MODULE_RUNTIME_HOME', None)
+USER = os.environ.get('MFMODULE_RUNTIME_USER', None)
+MFMODULE_RUNTIME_HOME = os.environ.get('MFMODULE_RUNTIME_HOME', None)
 
 
 def get_switch_master_pids():
@@ -22,7 +22,7 @@ def get_switch_master_pids():
             if 'switch/main.py' not in cmdline:
                 continue
             cwd = proc.cwd()
-            if not cwd.startswith(MODULE_RUNTIME_HOME):
+            if not cwd.startswith(MFMODULE_RUNTIME_HOME):
                 continue
             pids.append(proc.pid)
         except Exception:

--- a/adm/before_start_directory_observer
+++ b/adm/before_start_directory_observer
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-_make_directory_observer_conf >"${MODULE_RUNTIME_HOME}/tmp/config_auto/directory_observer.ini"
+_make_directory_observer_conf >"${MFMODULE_RUNTIME_HOME}/tmp/config_auto/directory_observer.ini"
 
-if ! test -s "${MODULE_RUNTIME_HOME}/tmp/config_auto/directory_observer.ini"; then
+if ! test -s "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/directory_observer.ini"; then
     echo "ERROR : can't make directory_observer configuration file"
     exit 1
 fi
@@ -15,7 +15,7 @@ from mfutil import mkdir_p
 config = os.environ.get('MFCONFIG', 'GENERIC')
 parser = ExtendedConfigParser(config=config, strict=False, inheritance='im', interpolation=None)
 
-parser.read("%s/tmp/config_auto/directory_observer.ini" % os.environ['MODULE_RUNTIME_HOME'])
+parser.read("%s/tmp/config_auto/directory_observer.ini" % os.environ['MFMODULE_RUNTIME_HOME'])
 
 for section in parser.sections():
     try:

--- a/adm/before_start_step.switch.main
+++ b/adm/before_start_step.switch.main
@@ -8,7 +8,7 @@ from mflog import getLogger
 
 SWITCH_DIRECTORIES =\
     os.environ.get("MFDATA_INTERNAL_PLUGINS_SWITCH_DIRECTORIES")
-MODULE_RUNTIME_HOME = os.environ['MODULE_RUNTIME_HOME']
+MFMODULE_RUNTIME_HOME = os.environ['MFMODULE_RUNTIME_HOME']
 log = getLogger('before_start_step.switch.main')
 
 for directory in SWITCH_DIRECTORIES.split(';'):
@@ -21,7 +21,7 @@ for directory in SWITCH_DIRECTORIES.split(';'):
         os.chmod(path, st.st_mode | stat.S_IWGRP)
 
 x = BashWrapper("_make_switch_conf >%s/tmp/config_auto/switch.ini" %
-                MODULE_RUNTIME_HOME)
+                MFMODULE_RUNTIME_HOME)
 if not x:
     log.warning("%s" % x)
     sys.exit(1)

--- a/adm/interactive_profile.custom
+++ b/adm/interactive_profile.custom
@@ -1,4 +1,4 @@
 {% extends "interactive_profile" %}
 {% block custom %}
-alias redis="redis-cli -s ${MODULE_RUNTIME_HOME}/var/redis.socket"
+alias redis="redis-cli -s ${MFMODULE_RUNTIME_HOME}/var/redis.socket"
 {% endblock %}

--- a/adm/mfdata_conf_monitor.py
+++ b/adm/mfdata_conf_monitor.py
@@ -7,12 +7,12 @@ from mfutil import BashWrapper, BashWrapperOrRaise
 from conf_monitor import ConfMonitorRunner, md5sumfile
 
 LOGGER = getLogger("conf_monitor")
-MODULE_RUNTIME_HOME = os.environ['MODULE_RUNTIME_HOME']
+MFMODULE_RUNTIME_HOME = os.environ['MFMODULE_RUNTIME_HOME']
 
 
 def make_new_directory_observer_conf():
     new_directory_observer_conf = \
-        "%s/tmp/tmp_directory_observer_conf2" % MODULE_RUNTIME_HOME
+        "%s/tmp/tmp_directory_observer_conf2" % MFMODULE_RUNTIME_HOME
     cmd = "_make_directory_observer_conf >%s" % new_directory_observer_conf
     BashWrapperOrRaise(cmd)
     return (new_directory_observer_conf,
@@ -21,7 +21,7 @@ def make_new_directory_observer_conf():
 
 def make_new_switch_conf():
     new_switch_conf = \
-        "%s/tmp/tmp_switch_conf2" % MODULE_RUNTIME_HOME
+        "%s/tmp/tmp_switch_conf2" % MFMODULE_RUNTIME_HOME
     cmd = "_make_switch_conf >%s" % new_switch_conf
     BashWrapperOrRaise(cmd)
     return (new_switch_conf,
@@ -30,14 +30,14 @@ def make_new_switch_conf():
 
 def get_old_directory_observer_conf():
     old_directory_observer_conf = \
-        "%s/tmp/config_auto/directory_observer.ini" % MODULE_RUNTIME_HOME
+        "%s/tmp/config_auto/directory_observer.ini" % MFMODULE_RUNTIME_HOME
     return (old_directory_observer_conf,
             md5sumfile(old_directory_observer_conf))
 
 
 def get_old_switch_conf():
     old_switch_conf = \
-        "%s/tmp/config_auto/switch.ini" % MODULE_RUNTIME_HOME
+        "%s/tmp/config_auto/switch.ini" % MFMODULE_RUNTIME_HOME
     return (old_switch_conf,
             md5sumfile(old_switch_conf))
 

--- a/adm/redis_metwork.py
+++ b/adm/redis_metwork.py
@@ -8,7 +8,7 @@ import redis
 REDIS_METWORK_PORT = int(os.getenv("MFDATA_REDIS_PORT"))
 REDIS_COLLECTD_INTERVAL = int(os.getenv("MFDATA_REDIS_COLLECTD_INTERVAL"))
 REDIS_SOCKET_PATH = "%s/var/redis.socket" % \
-    os.getenv("MODULE_RUNTIME_HOME")
+    os.getenv("MFMODULE_RUNTIME_HOME")
 REDIS_HOSTNAME = "%s__mfdata/redis-%s" % (os.getenv("MFCOM_HOSTNAME"),
                                           str(REDIS_METWORK_PORT))
 

--- a/adm/telegraf_collector_var_in_files_count.py
+++ b/adm/telegraf_collector_var_in_files_count.py
@@ -6,9 +6,9 @@ from telegraf_unixsocket_client import TelegrafUnixSocketClient
 from mfutil import BashWrapper
 from mflog import getLogger
 
-MODULE_RUNTIME_HOME = os.environ["MODULE_RUNTIME_HOME"]
-VAR_IN_PATH = os.path.join(MODULE_RUNTIME_HOME, "var", "in")
-SOCKET_PATH = os.path.join(MODULE_RUNTIME_HOME, "var",
+MFMODULE_RUNTIME_HOME = os.environ["MFMODULE_RUNTIME_HOME"]
+VAR_IN_PATH = os.path.join(MFMODULE_RUNTIME_HOME, "var", "in")
+SOCKET_PATH = os.path.join(MFMODULE_RUNTIME_HOME, "var",
                            "telegraf.socket")
 LOGGER = getLogger("telegraf_collector_var_in_files_count")
 

--- a/adm/templates/plugins/_common/config.ini
+++ b/adm/templates/plugins/_common/config.ini
@@ -12,7 +12,7 @@
 # - the old "name" key in this file is not used anymore
 
 # Version of the plugin (X.Y.Z)
-# If the value is {% raw %}{{MODULE_VERSION}}{% endraw %},
+# If the value is {% raw %}{{MFMODULE_VERSION}}{% endraw %},
 # the current module version is used
 version={{cookiecutter.version}}
 
@@ -95,7 +95,7 @@ args = --config-file={% raw %}{{MFDATA_CURRENT_CONFIG_INI_PATH}}{% endraw %} {% 
 # for CLI parsing if you use the standard Acquisition framework.
 # So, it's just a cleaner way to set some args but you can also set them on
 # "args" key).
-arg_redis-unix-socket-path = {% raw %}{{MODULE_RUNTIME_HOME}}{% endraw %}/var/redis.socket
+arg_redis-unix-socket-path = {% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/var/redis.socket
 {% endblock %}
 
 

--- a/adm/templates/plugins/_common/crontab
+++ b/adm/templates/plugins/_common/crontab
@@ -1,3 +1,3 @@
 # Your crontab fragment here
 # Example:
-# 0 2 * * * {% raw %}{{MFDATA_HOME}}{% endraw %}/bin/cronwrap.sh -l -e -- plugin_wrapper {{cookiecutter.name}} your_command.sh >>{% raw %}{{MODULE_RUNTIME_HOME}}{% endraw %}/log/your_command.log 2>&1
+# 0 2 * * * {% raw %}{{MFDATA_HOME}}{% endraw %}/bin/cronwrap.sh -l -e -- plugin_wrapper {{cookiecutter.name}} your_command.sh >>{% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/log/your_command.log 2>&1

--- a/adm/templates/plugins/archive/cookiecutter.json
+++ b/adm/templates/plugins/archive/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
+    "version": "{% raw %}{{MFMODULE_VERSION}}{% endraw %}",
     "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",

--- a/adm/templates/plugins/archive/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/archive/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/archive/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/archive/{{cookiecutter.name}}/config.ini
@@ -3,7 +3,7 @@
 {% set failurePolicy = "delete" %}
 
 {% block specific_args %}
-arg_dest-dir = {% raw %}{{MODULE_RUNTIME_HOME}}{% endraw %}/var/archive
+arg_dest-dir = {% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/var/archive
 # Arguments above this line should not be modified
 # Arguments below are asked for value when running
 #   bootstrap_plugin2.py create --template archive [--make [--install] [--delete] ] name

--- a/adm/templates/plugins/archive/{{cookiecutter.name}}/crontab
+++ b/adm/templates/plugins/archive/{{cookiecutter.name}}/crontab
@@ -1,5 +1,5 @@
 # keep files 5 days
-0 3 * * * {% raw %}{{MFDATA_HOME}}{% endraw %}/bin/cronwrap.sh --lock --low "find {% raw %}{{MODULE_RUNTIME_HOME}}{% endraw %}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
+0 3 * * * {% raw %}{{MFDATA_HOME}}{% endraw %}/bin/cronwrap.sh --lock --low "find {% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
 # remove empty directories
-0 4 * * * {% raw %}{{MFDATA_HOME}}{% endraw %}/bin/cronwrap.sh --lock --low "find {% raw %}{{MODULE_RUNTIME_HOME}}{% endraw %}/var/archive/ -type d -exec rmdir {} \;" >/dev/null 2>&1
+0 4 * * * {% raw %}{{MFDATA_HOME}}{% endraw %}/bin/cronwrap.sh --lock --low "find {% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/var/archive/ -type d -exec rmdir {} \;" >/dev/null 2>&1

--- a/adm/templates/plugins/default/cookiecutter.json
+++ b/adm/templates/plugins/default/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "python_version": ["python3", "python2"],
-    "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
+    "version": "{% raw %}{{MFMODULE_VERSION}}{% endraw %}",
     "one_line_summary": "one line summary about your plugin",
     "license": ["Proprietary", "BSD", "MIT", "GPL", "Specific"],
     "url": "http://yourpluginhomepage",

--- a/adm/templates/plugins/default/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/default/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/delete/cookiecutter.json
+++ b/adm/templates/plugins/delete/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
+    "version": "{% raw %}{{MFMODULE_VERSION}}{% endraw %}",
     "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",

--- a/adm/templates/plugins/delete/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/delete/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/delete/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/delete/{{cookiecutter.name}}/config.ini
@@ -4,7 +4,7 @@
 
 {% block specific_args %}
 # directory : sub-directory on which to remove files, as a relative path
-# under {% raw %}{{MODULE_RUNTIME_HOME}}{% endraw %}/var/in
+# under {% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/var/in
 {% if cookiecutter.directory != "" %}
 listened_directories={{cookiecutter.directory}};{% raw %}{{MFDATA_CURRENT_STEP_QUEUE}}{% endraw %}
 {% endif %}

--- a/adm/templates/plugins/fork/cookiecutter.json
+++ b/adm/templates/plugins/fork/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
+    "version": "{% raw %}{{MFMODULE_VERSION}}{% endraw %}",
     "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",

--- a/adm/templates/plugins/fork/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/fork/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/ftpsend/cookiecutter.json
+++ b/adm/templates/plugins/ftpsend/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
+    "version": "{% raw %}{{MFMODULE_VERSION}}{% endraw %}",
     "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",

--- a/adm/templates/plugins/ftpsend/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/ftpsend/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/ftpsend/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/ftpsend/{{cookiecutter.name}}/config.ini
@@ -54,7 +54,7 @@ switch_use_hardlink = True
 [step_reinject]
 cmd = {% raw %}{{MFDATA_CURRENT_PLUGIN_DIR}}{% endraw %}/reinject.py
 args = --config-file={% raw %}{{MFDATA_CURRENT_CONFIG_INI_PATH}}{% endraw %} {% raw %}{{MFDATA_CURRENT_STEP_QUEUE}}{% endraw %}
-arg_redis-unix-socket-path = {% raw %}{{MODULE_RUNTIME_HOME}}{% endraw %}/var/redis.socket
+arg_redis-unix-socket-path = {% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/var/redis.socket
 arg_reinject-dir = {% raw %}{{MFDATA_DATA_IN_DIR}}{% endraw %}/step.{% raw %}{{MFDATA_CURRENT_PLUGIN_NAME}}{% endraw %}.send
 arg_reinject-delay = {{cookiecutter.reinject_delay}}
 arg_reinject-attempts = {{cookiecutter.reinject_attempts}}

--- a/adm/templates/plugins/move/cookiecutter.json
+++ b/adm/templates/plugins/move/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "version": "{% raw %}{{MODULE_VERSION}}{% endraw %}",
+    "version": "{% raw %}{{MFMODULE_VERSION}}{% endraw %}",
     "one_line_summary": "one line summary about your plugin",
     "url": "http://yourpluginhomepage",
     "maintainer": "Firstname FAMILYNAME <email>",

--- a/adm/templates/plugins/move/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/move/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/config/Makefile
+++ b/config/Makefile
@@ -7,8 +7,8 @@ include $(MFCOM_HOME)/share/config_subdir.mk
 test:
 	layer_wrapper --layers=devtools@mfext noutf8.sh
 
-all:: $(MODULE_HOME)/config/circus.ini $(MODULE_HOME)/config/telegraf.conf $(MODULE_HOME)/config/content_by_lua.lua
+all:: $(MFMODULE_HOME)/config/circus.ini $(MFMODULE_HOME)/config/telegraf.conf $(MFMODULE_HOME)/config/content_by_lua.lua
 
-$(MODULE_HOME)/config/content_by_lua.lua: content_by_lua.lua
+$(MFMODULE_HOME)/config/content_by_lua.lua: content_by_lua.lua
 	layer_wrapper --layers=devtools@mfext -- test_globals_in_lua.sh $<
 	cp -f $< $@

--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -10,63 +10,63 @@ stop_children = True
 {% if MFDATA_NGINX_FLAG == "1" %}
 [watcher:nginx]
 cmd={{MFEXT_HOME}}/opt/openresty/nginx/sbin/nginx
-args=-p {{MODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
+args=-p {{MFMODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
 numprocesses=1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/nginx.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/nginx.log
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/nginx.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/nginx.log
 copy_env = True
 autostart = True
 respawn = True
 hooks.before_start=circus_hooks.before_start_shell
 hooks.after_stop=circus_hooks.after_stop_shell
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 {% endif %}
 
 [watcher:conf_monitor]                                                          
-cmd={{MODULE_HOME}}/bin/mfdata_conf_monitor.py                                         
+cmd={{MFMODULE_HOME}}/bin/mfdata_conf_monitor.py                                         
 args=                                                                           
 numprocesses = 1                                                                
 stdout_stream.class = FileStream                                                
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/conf_monitor.stdout        
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/conf_monitor.stdout        
 stderr_stream.class = FileStream                                                
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/conf_monitor.stderr        
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/conf_monitor.stderr        
 copy_env = True                                                                 
 autostart = True                                                                
 respawn = True           
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 stop_signal = 9
 hooks.before_start=circus_hooks.before_start_shell
 hooks.after_stop=circus_hooks.after_stop_shell
 
 [watcher:redis]
 cmd=redis-server
-args={{MODULE_RUNTIME_HOME}}/tmp/config_auto/redis.conf
+args={{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/redis.conf
 numprocesses = 1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/redis.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/redis.log
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/redis.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/redis.log
 copy_env = True
 autostart = True
 respawn = True
 hooks.before_start=circus_hooks.before_start_shell
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 
 [watcher:directory_observer]
 cmd=python3
-args=-m directory_observer.directory_observer --config={{MODULE_RUNTIME_HOME}}/tmp/config_auto/directory_observer.ini
+args=-m directory_observer.directory_observer --config={{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/directory_observer.ini
 numprocesses = 1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/directory_observer.stdout
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/directory_observer.stdout
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/directory_observer.stderr
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/directory_observer.stderr
 copy_env = True
 autostart = True
 respawn = True
 hooks.before_start=circus_hooks.before_start_shell
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 
 {% if MFDATA_ADMIN_HOSTNAME != "null" %}
 [watcher:telegraf_collector_var_in_files_count]
@@ -74,13 +74,13 @@ cmd={{MFDATA_HOME}}/bin/telegraf_collector_var_in_files_count.py
 args=
 numprocesses = 1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/telegraf_collector_var_in_files_count.stdout
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_var_in_files_count.stdout
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/telegraf_collector_var_in_files_count.stderr
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_var_in_files_count.stderr
 copy_env = True
 autostart = True
 respawn = True
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 {% endif %}
 
 {% if MFDATA_ADMIN_HOSTNAME_IP != "null" %}
@@ -88,18 +88,18 @@ working_dir = {{MODULE_RUNTIME_HOME}}/tmp
 {% if MFDATA_NGINX_FLAG == "1" %}
 [watcher:jsonlog2elasticsearch]
 cmd=layer_wrapper
-args=--layers=monitoring@mfext -- jsonlog2elasticsearch --transform-func=jsonlog2elasticsearch_metwork_addon.transform_func {{MFDATA_ADMIN_HOSTNAME_IP}} {{MFDATA_ADMIN_ELASTICSEARCH_HTTP_PORT}} nginx-%Y.%m.%d {{MODULE_RUNTIME_HOME}}/log/nginx_access.log
+args=--layers=monitoring@mfext -- jsonlog2elasticsearch --transform-func=jsonlog2elasticsearch_metwork_addon.transform_func {{MFDATA_ADMIN_HOSTNAME_IP}} {{MFDATA_ADMIN_ELASTICSEARCH_HTTP_PORT}} nginx-%Y.%m.%d {{MFMODULE_RUNTIME_HOME}}/log/nginx_access.log
 numprocesses = 1                                                                
 stdout_stream.class = FileStream                                                
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_nginx.log                  
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_nginx.log                  
 stderr_stream.class = FileStream                                                
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_nginx.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_nginx.log
 copy_env = True                                                                 
 autostart = True                                                                
 respawn = True                                                                  
 hooks.before_start=circus_hooks.before_start_shell                              
 hooks.after_stop=circus_hooks.after_stop_shell          
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 async_kill = True
 
 {% endif %}

--- a/config/config.ini
+++ b/config/config.ini
@@ -10,7 +10,7 @@ flag=1
 ###################
 [data_in]
 # Data preprocessing root (without / at the end)
-dir={{MODULE_RUNTIME_HOME}}/var/in
+dir={{MFMODULE_RUNTIME_HOME}}/var/in
 
 # Max lifetime for a file in trash subdir (in minutes)
 trash_max_lifetime=1440
@@ -43,7 +43,7 @@ minimal_level[DEV]=DEBUG
 # duplicate some log messages in JSON to a specific file (for external monitoring tool)
 # If json_file value is:
 # null => the feature is desactivated
-# AUTO => the json_file is @@@MODULE_RUNTIME_HOME@@@/log/json_logs.log if
+# AUTO => the json_file is @@@MFMODULE_RUNTIME_HOME@@@/log/json_logs.log if
 #         [admin]/hostname != null else null (desactivated)
 json_file=AUTO
 
@@ -65,8 +65,8 @@ json_minimal_level=WARNING
 ##### CIRCUS #####
 ##################
 [circus]
-endpoint = ipc://@@@MODULE_RUNTIME_HOME@@@/var/circus.socket
-pubsub_endpoint = ipc://@@@MODULE_RUNTIME_HOME@@@/var/circus_pubsub.socket
+endpoint = ipc://@@@MFMODULE_RUNTIME_HOME@@@/var/circus.socket
+pubsub_endpoint = ipc://@@@MFMODULE_RUNTIME_HOME@@@/var/circus_pubsub.socket
 
 
 ##############################
@@ -122,8 +122,8 @@ flag=1
 # nginx will listen on a unix socket
 # but, if you set a value != 0 bellow, it will also listen this tcp port
 port=9091
-upload_dir=@@@MODULE_RUNTIME_HOME@@@/var/in/incoming
-clientbody_temp_path=@@@MODULE_RUNTIME_HOME@@@/var/in/tmp/nginx
+upload_dir=@@@MFMODULE_RUNTIME_HOME@@@/var/in/incoming
+clientbody_temp_path=@@@MFMODULE_RUNTIME_HOME@@@/var/in/tmp/nginx
 # MB
 upload_max_body_size=100
 workers=@@@MFCOM_HARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2@@@

--- a/config/crontab.custom
+++ b/config/crontab.custom
@@ -3,6 +3,6 @@
 {% block custom %}
 {% raw %}
 # Garbage collector (files)
-* * * * * {{RUNTIME_SUFFIX}} {{MODULE_HOME}}/bin/cronwrap.sh --lock --timeout=600 --low --random-sleep=10 "garbage_collector.sh" >>{{MODULE_RUNTIME_HOME}}/log/garbage_collector.log 2>&1
+* * * * * {{RUNTIME_SUFFIX}} {{MFMODULE_HOME}}/bin/cronwrap.sh --lock --timeout=600 --low --random-sleep=10 "garbage_collector.sh" >>{{MFMODULE_RUNTIME_HOME}}/log/garbage_collector.log 2>&1
 {% endraw %}
 {% endblock %}

--- a/config/directory_observer.ini
+++ b/config/directory_observer.ini
@@ -62,7 +62,7 @@ redis_port={{MFDATA_REDIS_PORT}}
 
 # REDIS unix socket
 # if set to something != null, then overrides redis_server/redis_port
-redis_unix_socket={{MODULE_RUNTIME_HOME}}/var/redis.socket
+redis_unix_socket={{MFMODULE_RUNTIME_HOME}}/var/redis.socket
 
 # Value of the REDIS security timeout in seconds to avoid interminable
 # blockages during unavailability.

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -2,11 +2,11 @@
 daemon off;
 worker_processes {{MFDATA_NGINX_WORKERS}};
 {% if MFDATA_LOG_DEFAULT_LEVEL == "DEBUG" %}
-error_log  {{MODULE_RUNTIME_HOME}}/log/nginx_error.log debug;
+error_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_error.log debug;
 {% else %}
-error_log  {{MODULE_RUNTIME_HOME}}/log/nginx_error.log error;
+error_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_error.log error;
 {% endif %}
-pid        {{MODULE_RUNTIME_HOME}}/var/nginx.pid;
+pid        {{MFMODULE_RUNTIME_HOME}}/var/nginx.pid;
 
 # Main Loop Configuration
 events {
@@ -23,7 +23,7 @@ http {
     default_type  text/plain;
     # FIXME: ugly hack with ~~~1 and ~~~~2 to circumvent nginxfmt problem with JSON
     log_format main '~~~1 "@timestamp": "$time_iso8601", "from": "$remote_addr", "method": "$request_method", "uri": "$request_uri", "duration": $request_time, "status": $status, "request_length": $request_length, "reply_length": $bytes_sent ~~~2';
-    access_log  {{MODULE_RUNTIME_HOME}}/log/nginx_access.log  main;
+    access_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_access.log  main;
     client_body_temp_path {{MFDATA_NGINX_CLIENTBODY_TEMP_PATH}};
     client_max_body_size {{MFDATA_NGINX_UPLOAD_MAX_BODY_SIZE}}m;
     lua_package_path '{{MFDATA_HOME}}/config/?.lua;{{MFCOM_HOME}}/lib/?.lua;;';
@@ -32,7 +32,7 @@ http {
 
     server {
 
-        listen unix:{{MODULE_RUNTIME_HOME}}/var/nginx.socket backlog=40000;
+        listen unix:{{MFMODULE_RUNTIME_HOME}}/var/nginx.socket backlog=40000;
         {% if MFDATA_NGINX_PORT != "0" %}
         listen {{MFDATA_NGINX_PORT}} backlog=40000;
         {% endif %}

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -7,8 +7,8 @@ timeout 600
 tcp-keepalive 10
 save 60 1
 dbfilename redis_dump.rdb
-dir {{MODULE_RUNTIME_HOME}}/var/
-unixsocket {{MODULE_RUNTIME_HOME}}/var/redis.socket
+dir {{MFMODULE_RUNTIME_HOME}}/var/
+unixsocket {{MFMODULE_RUNTIME_HOME}}/var/redis.socket
 maxmemory {{MFDATA_REDIS_MAX_MEMORY}}mb
 maxmemory-policy allkeys-lru
 lua-time-limit 300000

--- a/config/redis_plugin_xxx.conf
+++ b/config/redis_plugin_xxx.conf
@@ -7,7 +7,7 @@ timeout 600
 tcp-keepalive 10
 save ""
 dbfilename redis_plugin_{{PLUGIN_NAME}}.rdb
-dir {{MODULE_RUNTIME_HOME}}/var/
-unixsocket {{MODULE_RUNTIME_HOME}}/var/redis_plugin_{{PLUGIN_NAME}}.socket
+dir {{MFMODULE_RUNTIME_HOME}}/var/
+unixsocket {{MFMODULE_RUNTIME_HOME}}/var/redis_plugin_{{PLUGIN_NAME}}.socket
 maxmemory 512mb
 maxmemory-policy allkeys-lru

--- a/config/telegraf.conf.custom
+++ b/config/telegraf.conf.custom
@@ -18,16 +18,16 @@
 {% endif %}
 
 [[inputs.redis]]
-  servers = ["unix://{{MODULE_RUNTIME_HOME}}/var/redis.socket"]
+  servers = ["unix://{{MFMODULE_RUNTIME_HOME}}/var/redis.socket"]
 
 [[inputs.procstat]]
-  pattern = "python.*circus.*plugins.*{{MODULE_RUNTIME_HOME}}/var/circus.socket.*CircusAutorestart"
-  user = "{{MODULE_RUNTIME_USER}}"
+  pattern = "python.*circus.*plugins.*{{MFMODULE_RUNTIME_HOME}}/var/circus.socket.*CircusAutorestart"
+  user = "{{MFMODULE_RUNTIME_USER}}"
   process_name = "circus_plugin_autorestart"
 
 [[inputs.procstat]]
-  pattern = "redis-server.*{{MODULE_RUNTIME_HOME}}/tmp/config_auto/redis.conf"
-  user = "{{MODULE_RUNTIME_USER}}"
+  pattern = "redis-server.*{{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/redis.conf"
+  user = "{{MFMODULE_RUNTIME_USER}}"
   process_name = "redis"
 
 {% endraw %}

--- a/doc/mfdata_additional_tutorials.md
+++ b/doc/mfdata_additional_tutorials.md
@@ -580,7 +580,7 @@ We could set an `arg_grib-to-netcdf-options` parameter in  the `convert_grib2/co
 grib_to_netcdf_options=-k 3 -d 0 -D NC_FLOAT
 
 ```
-Each parameter will be will transform into an environment variable whose pattern is `{MODULE}_{SECTION_NAME}_{PARAMETER_NAME}`, e.g. `MFDATA_PLUGIN_CONVERT_GRIB2_GRIB_TO_NETCDF_OPTIONS`
+Each parameter will be will transform into an environment variable whose pattern is `{MFMODULE}_{SECTION_NAME}_{PARAMETER_NAME}`, e.g. `MFDATA_PLUGIN_CONVERT_GRIB2_GRIB_TO_NETCDF_OPTIONS`
 
 .. note::
     - Environment variables are always in uppercase.
@@ -591,7 +591,7 @@ Each parameter will be will transform into an environment variable whose pattern
 
 Then, if you enter :
 ```bash
-env | grep "^${MODULE}_" | grep CONVERT
+env | grep "^${MFMODULE}_" | grep CONVERT
 ```
 
 You should see something like this:

--- a/doc/mfdata_deploy_plugin.md
+++ b/doc/mfdata_deploy_plugin.md
@@ -12,13 +12,13 @@ make release
 Then a `{plugin name}-{version}-1.metwork.mfdata.plugin` file is created, where:
 
 - {plugin name} is the name of the plugin
-- `{version}` is the value of the `version` parameter defined in the plugin `config.ini` file you enter when you create the plugin (default value is `${MODULE_VERSION}`)
+- `{version}` is the value of the `version` parameter defined in the plugin `config.ini` file you enter when you create the plugin (default value is `${MFMODULE_VERSION}`)
  
 
 You can change the `version` in  plugin `config.ini` file:
 ```cfg
 # Version of the plugin (X.Y.Z)
-# If the value is [MODULE_VERSION],
+# If the value is [MFMODULE_VERSION],
 # the current module version is used
 version=1.0.0
 ```

--- a/doc/mfdata_log.md
+++ b/doc/mfdata_log.md
@@ -83,7 +83,7 @@ def configure_logger(name, log_name):
 
 
 # Get the MFDATA root directory
-basedir = os.environ.get("MODULE_RUNTIME_HOME",
+basedir = os.environ.get("MFMODULE_RUNTIME_HOME",
                          os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
 
 # Get the MFDATA log directory

--- a/doc/mfdata_miscellaneous.md
+++ b/doc/mfdata_miscellaneous.md
@@ -400,8 +400,8 @@ Edit the `config.ini` plugin configuration file and rename `[step_main]` section
 cmd = {{MFDATA_CURRENT_PLUGIN_DIR}}/archive_image.py
 # Arguments for the cmd
 args = --config-file={{MFDATA_CURRENT_CONFIG_INI_PATH}} {{MFDATA_CURRENT_STEP_QUEUE}}
-arg_redis-unix-socket-path = {{MODULE_RUNTIME_HOME}}/var/redis.socket
-arg_dest-dir = {{MODULE_RUNTIME_HOME}}/var/archive
+arg_redis-unix-socket-path = {{MFMODULE_RUNTIME_HOME}}/var/redis.socket
+arg_dest-dir = {{MFMODULE_RUNTIME_HOME}}/var/archive
 # Arguments above this line should not be modified
 # Arguments below are asked for value when running
 #   bootstrap_plugin2.py create --template archive [--make [--install] [--delete] ] name
@@ -469,7 +469,7 @@ cmd = {{MFDATA_CURRENT_PLUGIN_DIR}}/convert_png.py
 
 # Arguments for the cmd
 args = --config-file={{MFDATA_CURRENT_CONFIG_INI_PATH}} {{MFDATA_CURRENT_STEP_QUEUE}}
-arg_redis-unix-socket-path = {{MODULE_RUNTIME_HOME}}/var/redis.socket
+arg_redis-unix-socket-path = {{MFMODULE_RUNTIME_HOME}}/var/redis.socket
 # Arguments above this line should not be modified
 # Arguments below are asked for value when running
 # command-template : command template to execute on each file
@@ -558,9 +558,9 @@ In order to (re)load the contab file:
 If you need to execute your `cron` command in the Metwork context, you should use the cron wrapper script `${MFDATA_HOME}/bin/cronwrap.sh`, e.g. :
 ```cfg
 {% raw %}
-{{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
+{{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFDATA_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >{{MODULE_RUNTIME_HOME}}/log/[your_log_filename] 2>&1
+{{MFDATA_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >{{MFMODULE_RUNTIME_HOME}}/log/[your_log_filename] 2>&1
 {% endraw %}
 ```
 

--- a/doc/mfdata_quick_start.md
+++ b/doc/mfdata_quick_start.md
@@ -199,10 +199,10 @@ To do this, go to the `move_image` plugin directory and enter the command:
 make release
 ```
 
-This will create a `.plugin` file that will be used to deploy the plugin, e.g. `move_image-[version]-1.metwork.mfdata.plugin` where `[version]` is the value of the `version` parameter of the move_image `config.ini` you enter when you create the plugin (default value is `${MODULE_VERSION}`). You may change it:
+This will create a `.plugin` file that will be used to deploy the plugin, e.g. `move_image-[version]-1.metwork.mfdata.plugin` where `[version]` is the value of the `version` parameter of the move_image `config.ini` you enter when you create the plugin (default value is `${MFMODULE_VERSION}`). You may change it:
 ```cfg
 # Version of the plugin (X.Y.Z)
-# If the value is [MODULE_VERSION],
+# If the value is [MFMODULE_VERSION],
 # the current module version is used
 version=1.0.0
 ```

--- a/integration_tests/0002_switch_ungzip_archive_plugins/test.sh
+++ b/integration_tests/0002_switch_ungzip_archive_plugins/test.sh
@@ -10,7 +10,7 @@ plugins.uninstall ungzip >/dev/null 2>&1
 plugins.uninstall foobar2 >/dev/null 2>&1
 rm -R foobar2* >/dev/null 2>&1
 
-DEST_DIR=${MODULE_RUNTIME_HOME}/var/archive/`date +%Y%m%d`
+DEST_DIR=${MFMODULE_RUNTIME_HOME}/var/archive/`date +%Y%m%d`
 rm -R ${DEST_DIR} >/dev/null 2>&1
 
 set -x
@@ -34,19 +34,19 @@ mfdata.start
 plugins.list
 _circusctl --endpoint ${MFDATA_CIRCUS_ENDPOINT} --timeout=10 status
 
-cp ../data/Example.png.gz ${MODULE_RUNTIME_HOME}/var/in/incoming
-ls -l ${MODULE_RUNTIME_HOME}/var/in/incoming
+cp ../data/Example.png.gz ${MFMODULE_RUNTIME_HOME}/var/in/incoming
+ls -l ${MFMODULE_RUNTIME_HOME}/var/in/incoming
 
 # We wait 10s maximum for the gzipped PNG file to be processed
 nb=0
-while [ ! -z "$(ls -A ${MODULE_RUNTIME_HOME}/var/in/incoming)" ]; do
+while [ ! -z "$(ls -A ${MFMODULE_RUNTIME_HOME}/var/in/incoming)" ]; do
     nb=$(($nb + 1))
     if [ $nb -eq 10 ]; then
         exit 1
     fi
     sleep 1
 done
-ls -l ${MODULE_RUNTIME_HOME}/var/in/incoming
+ls -l ${MFMODULE_RUNTIME_HOME}/var/in/incoming
 
 # We wait 10s maximum for creation of the archive directory
 nb=0
@@ -65,10 +65,10 @@ cat ${DEST_DIR}/Example.png.tags | grep first.core.original_basename | grep Exam
 plugins.uninstall foobar2
 plugins.uninstall ungzip
 
-nb3=`redis-cli -s ${MODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
+nb3=`redis-cli -s ${MFMODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
 if [ $nb3 -ne 0 ]; then
     echo $nb3 "tags left in redis"
-    cat ${MODULE_RUNTIME_HOME}/log/*.stderr
+    cat ${MFMODULE_RUNTIME_HOME}/log/*.stderr
     exit 1
 else
     echo "no tags left in redis : ok"

--- a/integration_tests/0003_delete_plugin/test.sh
+++ b/integration_tests/0003_delete_plugin/test.sh
@@ -8,7 +8,7 @@
 plugins.uninstall foobar3 >/dev/null 2>&1
 rm -R foobar3* >/dev/null 2>&1
 
-DEST_DIR=${MODULE_RUNTIME_HOME}/var/in/dir_delete
+DEST_DIR=${MFMODULE_RUNTIME_HOME}/var/in/dir_delete
 rm -R ${DEST_DIR} >/dev/null 2>&1
 mkdir ${DEST_DIR}
 
@@ -28,7 +28,7 @@ mfdata.start
 plugins.list
 _circusctl --endpoint ${MFDATA_CIRCUS_ENDPOINT} --timeout=10 status
 
-cp ../data/Example.png ${MODULE_RUNTIME_HOME}/var/in/incoming
+cp ../data/Example.png ${MFMODULE_RUNTIME_HOME}/var/in/incoming
 cp ../data/Example.png.gz ${DEST_DIR}
 
 sleep 1
@@ -38,18 +38,18 @@ if [ $n1 != 0 ]; then
     ls -l ${DEST_DIR}
     exit 1
 fi
-n2=`ls -A ${MODULE_RUNTIME_HOME}/var/in/step.foobar3.main| wc -l`
+n2=`ls -A ${MFMODULE_RUNTIME_HOME}/var/in/step.foobar3.main| wc -l`
 if [ $n2 != 0 ]; then
-    echo ${MODULE_RUNTIME_HOME}/var/in/step.foobar3.main is not empty
-    ls -l ${MODULE_RUNTIME_HOME}/var/in/step.foobar3.main
+    echo ${MFMODULE_RUNTIME_HOME}/var/in/step.foobar3.main is not empty
+    ls -l ${MFMODULE_RUNTIME_HOME}/var/in/step.foobar3.main
     exit 1
 fi
 plugins.uninstall foobar3
 
-nb3=`redis-cli -s ${MODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
+nb3=`redis-cli -s ${MFMODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
 if [ $nb3 -ne 0 ]; then
     echo $nb3 "tags left in redis"
-    cat ${MODULE_RUNTIME_HOME}/log/*.stderr
+    cat ${MFMODULE_RUNTIME_HOME}/log/*.stderr
     exit 1
 else
     echo "no tags left in redis : ok"

--- a/integration_tests/0004_move_plugin/test.sh
+++ b/integration_tests/0004_move_plugin/test.sh
@@ -8,7 +8,7 @@
 plugins.uninstall foobar4 >/dev/null 2>&1
 rm -R foobar4* >/dev/null 2>&1
 
-DEST_DIR=${MODULE_RUNTIME_HOME}/var/in/dir_move
+DEST_DIR=${MFMODULE_RUNTIME_HOME}/var/in/dir_move
 rm -R ${DEST_DIR} >/dev/null 2>&1
 mkdir ${DEST_DIR}
 
@@ -28,7 +28,7 @@ mfdata.start
 plugins.list
 _circusctl --endpoint ${MFDATA_CIRCUS_ENDPOINT} --timeout=10 status
 
-cp ../data/Example.png ${MODULE_RUNTIME_HOME}/var/in/incoming
+cp ../data/Example.png ${MFMODULE_RUNTIME_HOME}/var/in/incoming
 
 sleep 1
 ls -l ${DEST_DIR}
@@ -41,10 +41,10 @@ fi
 
 plugins.uninstall foobar4
 
-nb3=`redis-cli -s ${MODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
+nb3=`redis-cli -s ${MFMODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
 if [ $nb3 -ne 0 ]; then
     echo $nb3 "tags left in redis"
-    cat ${MODULE_RUNTIME_HOME}/log/*.stderr
+    cat ${MFMODULE_RUNTIME_HOME}/log/*.stderr
     exit 1
 else
     echo "no tags left in redis : ok"

--- a/integration_tests/0005_fork_template/test.sh
+++ b/integration_tests/0005_fork_template/test.sh
@@ -23,17 +23,17 @@ mfdata.start
 plugins.list
 _circusctl --endpoint ${MFDATA_CIRCUS_ENDPOINT} --timeout=10 status
 
-cp ../data/Example.png ${MODULE_RUNTIME_HOME}/var/in/incoming
+cp ../data/Example.png ${MFMODULE_RUNTIME_HOME}/var/in/incoming
 
 sleep 1
-diff ../data/Example.png ${MODULE_RUNTIME_HOME}/var/in//tmp/foobar5.main/*.tst
+diff ../data/Example.png ${MFMODULE_RUNTIME_HOME}/var/in//tmp/foobar5.main/*.tst
 
 plugins.uninstall foobar5
 
-nb3=`redis-cli -s ${MODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
+nb3=`redis-cli -s ${MFMODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
 if [ $nb3 -ne 0 ]; then
     echo $nb3 "tags left in redis"
-    cat ${MODULE_RUNTIME_HOME}/log/*.stderr
+    cat ${MFMODULE_RUNTIME_HOME}/log/*.stderr
     exit 1
 else
     echo "no tags left in redis : ok"

--- a/integration_tests/0006_process_a_thousand_files/test.sh
+++ b/integration_tests/0006_process_a_thousand_files/test.sh
@@ -8,7 +8,7 @@
 plugins.uninstall foobar6 >/dev/null 2>&1
 rm -R foobar6* >/dev/null 2>&1
 
-DEST_DIR=${MODULE_RUNTIME_HOME}/var/archive/`date +%Y%m%d`
+DEST_DIR=${MFMODULE_RUNTIME_HOME}/var/archive/`date +%Y%m%d`
 rm -R ${DEST_DIR} >/dev/null 2>&1
 
 set -x
@@ -34,12 +34,12 @@ set +x
 echo "Injecting 1000 files"
 for ((i=1;i<=1000;i++)); do
     cp ../data/Example.png Example${i}.png
-    mv Example${i}.png ${MODULE_RUNTIME_HOME}/var/in/incoming
+    mv Example${i}.png ${MFMODULE_RUNTIME_HOME}/var/in/incoming
 done
 
 # We wait 60s maximum for all PNG files to be processed
 nb=0
-while [ ! -z "$(ls -A ${MODULE_RUNTIME_HOME}/var/in/incoming)" ]; do
+while [ ! -z "$(ls -A ${MFMODULE_RUNTIME_HOME}/var/in/incoming)" ]; do
     nb=$(($nb + 1))
     if [ $nb -eq 60 ]; then
         exit 1
@@ -65,7 +65,7 @@ while [ $nb1 -lt 1000 ]; do
     nb=$(($nb + 1))
     if [ $nb -eq 20 ]; then
         echo "Data files are missing, only " $nb1
-        cat ${MODULE_RUNTIME_HOME}/log/*.stderr
+        cat ${MFMODULE_RUNTIME_HOME}/log/*.stderr
         exit 1
     fi
     sleep 1
@@ -79,7 +79,7 @@ while [ $nb2 -lt 1000 ]; do
     nb=$(($nb + 1))
     if [ $nb -eq 10 ]; then
         echo "Tags files are missing, only " $nb2
-        cat ${MODULE_RUNTIME_HOME}/log/*.stderr
+        cat ${MFMODULE_RUNTIME_HOME}/log/*.stderr
         exit 1
     fi
     sleep 1
@@ -87,10 +87,10 @@ while [ $nb2 -lt 1000 ]; do
 done
 echo "1000 tags files : ok"
 
-nb3=`redis-cli -s ${MODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
+nb3=`redis-cli -s ${MFMODULE_RUNTIME_HOME}/var/redis.socket keys "*" |grep xattr |wc -l`
 if [ $nb3 -ne 0 ]; then
     echo $nb3 "tags left in redis"
-    cat ${MODULE_RUNTIME_HOME}/log/*.stderr
+    cat ${MFMODULE_RUNTIME_HOME}/log/*.stderr
     exit 1
 else
     echo "no tags left in redis : ok"

--- a/layers/layer1_python3/0100_directory_observer/directory_observer/directory_observer.py
+++ b/layers/layer1_python3/0100_directory_observer/directory_observer/directory_observer.py
@@ -350,7 +350,7 @@ def init():
                 ficconfig = None
         else:
             ficconfig = None
-            homedir = os.environ[os.environ['MODULE'] + '_HOME']
+            homedir = os.environ[os.environ['MFMODULE'] + '_HOME']
             for directory in DEFAULT_HOME_CONFIG_DIRS:
                 ficconfig = os.path.abspath(homedir)
                 ficconfig = os.path.join(ficconfig, directory)

--- a/layers/layer1_python3/0200_xattrfile/xattrfile/__init__.py
+++ b/layers/layer1_python3/0200_xattrfile/xattrfile/__init__.py
@@ -17,8 +17,8 @@ RED = None
 
 UNITTESTS_RED = None
 
-#: MODULE_RUNTIME_HOME value
-MODULE_RUNTIME_HOME = os.environ.get('MODULE_RUNTIME_HOME', None)
+#: MFMODULE_RUNTIME_HOME value
+MFMODULE_RUNTIME_HOME = os.environ.get('MFMODULE_RUNTIME_HOME', None)
 
 
 def unittests_get_redis_callable():
@@ -33,7 +33,7 @@ def metwork_get_redis_callable():
     """Create or return a redis instance in a metwork module context.
 
     To create an instance, we use a unix socket connection on
-    ${MODULE_RUNTIME_HOME}/var/redis.socket
+    ${MFMODULE_RUNTIME_HOME}/var/redis.socket
 
     Returns:
         redis connection (redis.Redis object).
@@ -42,10 +42,10 @@ def metwork_get_redis_callable():
     global RED
     # If the connection is not initialized, create a new one
     if RED is None:
-        if MODULE_RUNTIME_HOME is None:
+        if MFMODULE_RUNTIME_HOME is None:
             RED = unittests_get_redis_callable()
         else:
-            socket_path = os.path.join(MODULE_RUNTIME_HOME, "var",
+            socket_path = os.path.join(MFMODULE_RUNTIME_HOME, "var",
                                        "redis.socket")
             RED = redis.Redis(unix_socket_path=socket_path)
     return RED

--- a/layers/layer1_python3/0300_acquisition/acquisition/archive_step.py
+++ b/layers/layer1_python3/0300_acquisition/acquisition/archive_step.py
@@ -46,7 +46,8 @@ class AcquisitionArchiveStep(AcquisitionStep):
 
     def init(self):
         if self.args.dest_dir is None:
-            module_runtime_home = os.environ.get('MODULE_RUNTIME_HOME', '/tmp')
+            module_runtime_home = os.environ.get('MFMODULE_RUNTIME_HOME',
+                                                 '/tmp')
             self.archive_dir = os.path.join(module_runtime_home,
                                             'var', 'archive')
         else:

--- a/layers/layer1_python3/0300_acquisition/acquisition/stats.py
+++ b/layers/layer1_python3/0300_acquisition/acquisition/stats.py
@@ -9,9 +9,9 @@ except ImportError:
 from statsd import StatsClient
 
 HOSTNAME = os.environ.get("MFCOM_HOSTNAME", "unknown")
-MODULE = os.environ["MODULE"]
-ADMIN_HOSTNAME_IP = os.environ.get("%s_ADMIN_HOSTNAME_IP" % MODULE, "null")
-STATSD_PORT = int(os.environ.get("%s_TELEGRAF_STATSD_PORT" % MODULE, "0"))
+MFMODULE = os.environ["MFMODULE"]
+ADMIN_HOSTNAME_IP = os.environ.get("%s_ADMIN_HOSTNAME_IP" % MFMODULE, "null")
+STATSD_PORT = int(os.environ.get("%s_TELEGRAF_STATSD_PORT" % MFMODULE, "0"))
 
 __CACHE = {}
 
@@ -81,7 +81,7 @@ class AcquisitionStatsDClient(object):
 
     def _get_suffix(self):
         if self.__suffix_cache is None:
-            tmp = ["", "module=%s" % MODULE.lower(), "host=%s" % HOSTNAME]
+            tmp = ["", "module=%s" % MFMODULE.lower(), "host=%s" % HOSTNAME]
             if self.plugin_name is not None:
                 tmp.append("plugin=%s" % self.plugin_name)
             if self.step_name is not None:

--- a/layers/layer1_python3/0300_acquisition/acquisition/step.py
+++ b/layers/layer1_python3/0300_acquisition/acquisition/step.py
@@ -18,7 +18,7 @@ from mfutil import get_utc_unix_timestamp
 from mfutil.plugins import MFUtilPluginBaseNotInitialized
 from mfutil.plugins import get_installed_plugins
 from acquisition.utils import _set_custom_environment, \
-    get_plugin_step_directory_path, MODULE_RUNTIME_HOME, _get_tmp_filepath, \
+    get_plugin_step_directory_path, MFMODULE_RUNTIME_HOME, _get_tmp_filepath, \
     _make_config_file_parser_class, _get_or_make_trash_dir
 from acquisition.stats import get_stats_client
 
@@ -427,7 +427,7 @@ class AcquisitionStep(object):
             (string) the fullpath of the plugin directory.
 
         """
-        return os.path.join(MODULE_RUNTIME_HOME,
+        return os.path.join(MFMODULE_RUNTIME_HOME,
                             'var', 'plugins', self.plugin_name)
 
     def move_to_plugin_step(self, xaf, plugin_name, step_name):

--- a/layers/layer1_python3/0300_acquisition/acquisition/utils.py
+++ b/layers/layer1_python3/0300_acquisition/acquisition/utils.py
@@ -2,10 +2,10 @@ import os
 from mfutil import mkdir_p_or_die, get_unique_hexa_identifier
 from acquisition.configargparse_confparser import StepConfigFileParser
 
-MODULE_RUNTIME_HOME = os.environ.get('MODULE_RUNTIME_HOME', '/tmp')
-IN_DIR = os.path.join(MODULE_RUNTIME_HOME, "var", "in")
-TMP_DIR = os.path.join(MODULE_RUNTIME_HOME, "var", "in", "tmp")
-TRASH_DIR = os.path.join(MODULE_RUNTIME_HOME, "var", "in", "trash")
+MFMODULE_RUNTIME_HOME = os.environ.get('MFMODULE_RUNTIME_HOME', '/tmp')
+IN_DIR = os.path.join(MFMODULE_RUNTIME_HOME, "var", "in")
+TMP_DIR = os.path.join(MFMODULE_RUNTIME_HOME, "var", "in", "tmp")
+TRASH_DIR = os.path.join(MFMODULE_RUNTIME_HOME, "var", "in", "trash")
 
 
 def get_plugin_step_directory_path(plugin_name, step_name):
@@ -13,7 +13,7 @@ def get_plugin_step_directory_path(plugin_name, step_name):
 
 
 def _set_custom_environment(plugin_name, step_name):
-    module_runtime_home = MODULE_RUNTIME_HOME
+    module_runtime_home = MFMODULE_RUNTIME_HOME
     os.environ['MFDATA_CURRENT_PLUGIN_NAME'] = plugin_name
     os.environ['MFDATA_CURRENT_STEP_NAME'] = step_name
     os.environ['MFDATA_CURRENT_PLUGIN_DIR'] = \

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -6,7 +6,7 @@ all:: $(MFDATA_HOME)/share/plugins
 $(MFDATA_HOME)/share/plugins:
 	/bin/rm -rf $(MFDATA_HOME)/share/plugins
 	mkdir $(MFDATA_HOME)/share/plugins
-	for PLUGIN in $(PLUGINS); do cd $${PLUGIN} && export MODULE_VERSION=`guess_version.sh` && rm -f *.plugin && make release || exit 1 && mv *.plugin $${MFDATA_HOME}/share/plugins && cd ..; done
+	for PLUGIN in $(PLUGINS); do cd $${PLUGIN} && export MFMODULE_VERSION=`guess_version.sh` && rm -f *.plugin && make release || exit 1 && mv *.plugin $${MFDATA_HOME}/share/plugins && cd ..; done
 
 clean::
 	/bin/rm -rf $(MFDATA_HOME)/share/plugins

--- a/plugins/amqp_listener/config.ini
+++ b/plugins/amqp_listener/config.ini
@@ -13,9 +13,9 @@
 name=amqp_listener
 
 # Version of the plugin (X.Y.Z)
-# If the value is {{MODULE_VERSION}},
+# If the value is {{MFMODULE_VERSION}},
 # the current module version is used
-version={{MODULE_VERSION}}
+version={{MFMODULE_VERSION}}
 
 # Summary (one line) of the goal of the plugin
 summary=amqp plugin listener

--- a/plugins/debug/config.ini
+++ b/plugins/debug/config.ini
@@ -1,6 +1,6 @@
 [general]
 name=debug
-version={{MODULE_VERSION}}
+version={{MFMODULE_VERSION}}
 summary=plugin which helps to debug mfdata plugins
 license=BSD
 url=http://metwork
@@ -10,5 +10,5 @@ vendor=MetWork
 [step_main]
 cmd = {{MFDATA_CURRENT_PLUGIN_DIR}}/main.py
 args = --config-file={{MFDATA_CURRENT_CONFIG_INI_PATH}} {{MFDATA_CURRENT_STEP_QUEUE}}
-arg_redis-unix-socket-path = {{MODULE_RUNTIME_HOME}}/var/redis.socket
+arg_redis-unix-socket-path = {{MFMODULE_RUNTIME_HOME}}/var/redis.socket
 numprocesses = 1

--- a/plugins/debug/crontab
+++ b/plugins/debug/crontab
@@ -1,5 +1,5 @@
 # keep files 1 day
-0 3 * * * {{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MODULE_RUNTIME_HOME}}/var/debug/ -type f -mtime +1 -exec rm -f {} \;" >/dev/null 2>&1
+0 3 * * * {{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/debug/ -type f -mtime +1 -exec rm -f {} \;" >/dev/null 2>&1
 
 # remove empty directories
-0 4 * * * {{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MODULE_RUNTIME_HOME}}/var/debug/ -type d -exec rmdir {} \;" >/dev/null 2>&1
+0 4 * * * {{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/debug/ -type d -exec rmdir {} \;" >/dev/null 2>&1

--- a/plugins/debug/main.py
+++ b/plugins/debug/main.py
@@ -10,7 +10,7 @@ class DebugMainStep(AcquisitionArchiveStep):
     _shadow = True
 
     def init(self):
-        module_runtime_home = os.environ.get('MODULE_RUNTIME_HOME', '/tmp')
+        module_runtime_home = os.environ.get('MFMODULE_RUNTIME_HOME', '/tmp')
         self.args.dest_dir = os.path.join(module_runtime_home, 'var',
                                           'debug')
         self.args.strftime_template = \

--- a/plugins/mqtt_listener/config.ini
+++ b/plugins/mqtt_listener/config.ini
@@ -13,9 +13,9 @@
 name=mqtt_listener
 
 # Version of the plugin (X.Y.Z)
-# If the value is {{MODULE_VERSION}},
+# If the value is {{MFMODULE_VERSION}},
 # the current module version is used
-version={{MODULE_VERSION}}
+version={{MFMODULE_VERSION}}
 
 # Summary (one line) of the goal of the plugin
 summary=mqtt listener plugin

--- a/plugins/switch/config.ini
+++ b/plugins/switch/config.ini
@@ -1,6 +1,6 @@
 [general]
 name=switch
-version={{MODULE_VERSION}}
+version={{MFMODULE_VERSION}}
 summary=plugin which feeds other plugins depending on file types
 license=BSD
 url=http://metwork
@@ -42,7 +42,7 @@ args = --config-file={{MFDATA_CURRENT_CONFIG_INI_PATH}} --no-match-policy={{MFDA
 # for CLI parsing if you use the standard Acquisition framework.
 # So, it's just a cleaner way to set some args but you can also set them on
 # "args" key).
-arg_redis-unix-socket-path = {{MODULE_RUNTIME_HOME}}/var/redis.socket
+arg_redis-unix-socket-path = {{MFMODULE_RUNTIME_HOME}}/var/redis.socket
 
 # FIXME: no magic any more (=> doc, template...)
 listened_directories={{MFDATA_INTERNAL_PLUGINS_SWITCH_DIRECTORIES}};{{MFDATA_CURRENT_STEP_QUEUE}}

--- a/plugins/switch/main.py
+++ b/plugins/switch/main.py
@@ -30,7 +30,7 @@ class AcquisitionSwitchStep(AcquisitionStep):
 
     def init(self):
         self.in_dir = os.environ['MFDATA_DATA_IN_DIR']
-        conf_file = os.path.join(os.environ['MODULE_RUNTIME_HOME'],
+        conf_file = os.path.join(os.environ['MFMODULE_RUNTIME_HOME'],
                                  "tmp", "config_auto", "switch.ini")
         if not os.path.exists(conf_file):
             self.error_and_die("no switch configuration file")

--- a/plugins/unbzip2/config.ini
+++ b/plugins/unbzip2/config.ini
@@ -1,6 +1,6 @@
 [general]
 name=unbzip2
-version={{MODULE_VERSION}}
+version={{MFMODULE_VERSION}}
 summary=plugin which unbzip2 incoming files and reinject them into the switch plugin
 license=BSD
 url=http://metwork
@@ -42,7 +42,7 @@ args = --config-file={{MFDATA_CURRENT_CONFIG_INI_PATH}} {{MFDATA_CURRENT_STEP_QU
 # for CLI parsing if you use the standard Acquisition framework.
 # So, it's just a cleaner way to set some args but you can also set them on
 # "args" key).
-arg_redis-unix-socket-path = {{MODULE_RUNTIME_HOME}}/var/redis.socket
+arg_redis-unix-socket-path = {{MFMODULE_RUNTIME_HOME}}/var/redis.socket
 
 # FIXME
 # Directory in which decompressed files will be reinjected.

--- a/plugins/ungzip/config.ini
+++ b/plugins/ungzip/config.ini
@@ -1,6 +1,6 @@
 [general]
 name=ungzip
-version={{MODULE_VERSION}}
+version={{MFMODULE_VERSION}}
 summary=plugin which ungzip incoming files and reinject them into the switch plugin
 license=BSD
 url=http://metwork
@@ -42,7 +42,7 @@ args = --config-file={{MFDATA_CURRENT_CONFIG_INI_PATH}} {{MFDATA_CURRENT_STEP_QU
 # for CLI parsing if you use the standard Acquisition framework.
 # So, it's just a cleaner way to set some args but you can also set them on
 # "args" key).
-arg_redis-unix-socket-path = {{MODULE_RUNTIME_HOME}}/var/redis.socket
+arg_redis-unix-socket-path = {{MFMODULE_RUNTIME_HOME}}/var/redis.socket
 
 # FIXME
 # Directory in which decompressed files will be reinjected.


### PR DESCRIPTION
…E_HOME becomes MFMODULE_HOME and so on)

BREAKING CHANGE: old variables names are no longer defined, they should not be used anymore (be careful with existing plugins)