### PR TITLE
fix: remove rlimit_core (because of `ulimit -c 0` in mfext)

### DIFF
--- a/adm/templates/plugins/_common/config.ini
+++ b/adm/templates/plugins/_common/config.ini
@@ -151,13 +151,11 @@ timeout=600
 # rlimit_nofile => maximum number of open file descriptors for the current process.
 # rlimit_stack => maximum size (in bytes) of the call stack for the current process.
 #     This only affects the stack of the main thread in a multi-threaded process.
-# rlimit_core => maximum size (in bytes) of a core file that the current process can create.
 # rlimit_fsize =>  maximum size of a file which the process may create.
 # (empty value means no limit)
 rlimit_as = 1000000000
 rlimit_nofile = 1000
 rlimit_stack = 10000000
-rlimit_core = 10000000
 rlimit_fsize = 10000000000
 {% endblock %}
 
@@ -176,7 +174,6 @@ rlimit_fsize = 10000000000
 # rlimit_as = 1000000000
 # rlimit_nofile = 1000
 # rlimit_stack = 10000000
-# rlimit_core = 100000
 # rlimit_fsize = 100000000
 # log_split_stdout_stderr=AUTO
 # log_split_multiple_workers=AUTO

--- a/adm/templates/plugins/ftpsend/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/ftpsend/{{cookiecutter.name}}/config.ini
@@ -61,6 +61,5 @@ rlimit_as = 1000000000
 rlimit_nofile = 1000
 rlimit_nproc = 100
 rlimit_stack = 10000000
-rlimit_core = 10000000
 rlimit_fsize = 10000000000
 {% endblock %}

--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -94,7 +94,9 @@ max_age_variance = {{STEP.max_age}}
 
 {% endif -%}
 {% for key, value in STEP.rlimits.items()|sort() %}
+{% if key != "core" -%}
 rlimit_{{key}} = {{value}}
+{% endif -%}
 {% endfor %}
 
     {% endfor %}
@@ -119,7 +121,9 @@ max_age_variance = {{EXTRA.max_age}}
 
 {% endif -%}
 {% for key, value in EXTRA.rlimits.items()|sort() %}
+{% if key != "core" -%}
 rlimit_{{key}} = {{value}}
+{% endif -%}
 {% endfor %}
 
     {% endfor %}

--- a/doc/mfdata_additional_tutorials.md
+++ b/doc/mfdata_additional_tutorials.md
@@ -460,14 +460,12 @@ _ _ _
 # rlimit_nofile => maximum number of open file descriptors for the current process.
 # rlimit_stack => maximum size (in bytes) of the call stack for the current process.
 #     This only affects the stack of the main thread in a multi-threaded process.
-# rlimit_core => maximum size (in bytes) of a core file that the current process can create.
 # rlimit_fsize =>  maximum size of a file which the process may create.
 # (empty value means no limit)
 #
 rlimit_as = 10000000000
 rlimit_nofile = 1000
 rlimit_stack = 10000000
-rlimit_core = 10000000000
 rlimit_fsize = 10000000000
 ```
 

--- a/doc/mfdata_tuning_monitoring.md
+++ b/doc/mfdata_tuning_monitoring.md
@@ -23,14 +23,12 @@ You are able to control resource limits for each step of a plugin by setting the
 # rlimit_nofile => maximum number of open file descriptors for the current process.
 # rlimit_stack => maximum size (in bytes) of the call stack for the current process.
 #     This only affects the stack of the main thread in a multi-threaded process.
-# rlimit_core => maximum size (in bytes) of a core file that the current process can create.
 # rlimit_fsize =>  maximum size of a file which the process may create.
 # (empty value means no limit)
 rlimit_as = 1000000000
 rlimit_nofile = 1000
 rlimit_nproc = 100
 rlimit_stack = 10000000
-rlimit_core = 10000000
 rlimit_fsize = 100000000
 ```
 


### PR DESCRIPTION
Close: #684 (mfdata part)