### PR TITLE
feat: remove absolute log paths from log_proxy usages (LOGPROXY_LOG_D…

### DIFF
--- a/.metwork-framework/cheatsheet.md
+++ b/.metwork-framework/cheatsheet.md
@@ -92,7 +92,7 @@ As `mfdata` unix user:
 | --- | --- |
 | **`config.ini`** | main plugin configuration file |
 | **`Makefile`** | build configuration file (you probably don't need to touch this unless you have specific build directives to add to the `custom::` target) |
-| `crontab` | plugin crontab (use something like `* * * * * {{MFDATA_HOME}}/bin/cronwrap.sh -l -e -- plugin_wrapper {YOUR_PLUGIN_NAME} {YOUR_COMMAND} >>{{MODULE_RUNTIME_HOME}}/log/your_command.log 2>&1` for each line to execute your command in your plugin environement) |
+| `crontab` | plugin crontab (use something like `* * * * * {{MFDATA_HOME}}/bin/cronwrap.sh -l -e -- plugin_wrapper {YOUR_PLUGIN_NAME} {YOUR_COMMAND} >>your_command.log 2>&1` for each line to execute your command in your plugin environement) |
 | `local/` | local subdirectory (it mainly holds the python virtualenv), never touch this it's automatically generated) |
 | `bin/` | if you put an executable in this directory, it will be available in `PATH` (in your plugin environment) |
 | `lib/` | thie library directory will be available in `LD_LIBRARY_PATH` and in `PYTHONPATH` (in your plugin environment), so you can put here shared libraries or python files you want to include easily |

--- a/.metwork-framework/cheatsheet.md
+++ b/.metwork-framework/cheatsheet.md
@@ -92,7 +92,7 @@ As `mfdata` unix user:
 | --- | --- |
 | **`config.ini`** | main plugin configuration file |
 | **`Makefile`** | build configuration file (you probably don't need to touch this unless you have specific build directives to add to the `custom::` target) |
-| `crontab` | plugin crontab (use something like `* * * * * {{MFDATA_HOME}}/bin/cronwrap.sh -l -e -- plugin_wrapper {YOUR_PLUGIN_NAME} {YOUR_COMMAND} >>your_command.log 2>&1` for each line to execute your command in your plugin environement) |
+| `crontab` | plugin crontab (use something like `* * * * * {{MFDATA_HOME}}/bin/cronwrap.sh -l -e -- plugin_wrapper {YOUR_PLUGIN_NAME} {YOUR_COMMAND} >>{{MODULE_RUNTIME_HOME}}/log/your_command.log 2>&1` for each line to execute your command in your plugin environement) |
 | `local/` | local subdirectory (it mainly holds the python virtualenv), never touch this it's automatically generated) |
 | `bin/` | if you put an executable in this directory, it will be available in `PATH` (in your plugin environment) |
 | `lib/` | thie library directory will be available in `LD_LIBRARY_PATH` and in `PYTHONPATH` (in your plugin environment), so you can put here shared libraries or python files you want to include easily |

--- a/adm/templates/plugins/_common/crontab
+++ b/adm/templates/plugins/_common/crontab
@@ -1,3 +1,3 @@
 # Your crontab fragment here
 # Example:
-# 0 2 * * * {% raw %}{{MFDATA_HOME}}{% endraw %}/bin/cronwrap.sh --lock --log-capture-to {% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/log/your_command.log -- plugin_wrapper {{cookiecutter.name}} your_command.sh
+# 0 2 * * * {% raw %}{{MFDATA_HOME}}{% endraw %}/bin/cronwrap.sh --lock --log-capture-to your_command.log -- plugin_wrapper {{cookiecutter.name}} your_command.sh

--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -10,7 +10,7 @@ stop_children = True
 {% if MFDATA_NGINX_FLAG == "1" %}
 [watcher:nginx]
 cmd=log_proxy_wrapper
-args=--stdout {{MFMODULE_RUNTIME_HOME}}/log/nginx_access.log --stderr {{MFMODULE_RUNTIME_HOME}}/log/nginx_error.log -- {{MFEXT_HOME}}/opt/openresty/nginx/sbin/nginx -p {{MFMODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
+args=--stdout nginx_access.log --stderr nginx_error.log -- {{MFEXT_HOME}}/opt/openresty/nginx/sbin/nginx -p {{MFMODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
 numprocesses=1
 copy_env = True
 autostart = True
@@ -23,7 +23,7 @@ working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 
 [watcher:conf_monitor]                                                          
 cmd=log_proxy_wrapper
-args=--stdout {{MFMODULE_RUNTIME_HOME}}/log/conf_monitor.log --stderr STDOUT -- {{MFMODULE_HOME}}/bin/mfdata_conf_monitor.py                                         
+args=--stdout conf_monitor.log --stderr STDOUT -- {{MFMODULE_HOME}}/bin/mfdata_conf_monitor.py                                         
 args=                                                                           
 numprocesses = 1                                                                
 copy_env = True                                                                 
@@ -37,7 +37,7 @@ hooks.after_stop=mfext.circus_hooks.after_stop_shell
 
 [watcher:redis]
 cmd=log_proxy_wrapper
-args=--stdout {{MFMODULE_RUNTIME_HOME}}/log/redis.log --stderr STDOUT -- redis-server {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/redis.conf
+args=--stdout redis.log --stderr STDOUT -- redis-server {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/redis.conf
 numprocesses = 1
 copy_env = True
 autostart = True
@@ -48,7 +48,7 @@ working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 
 [watcher:directory_observer]
 cmd=log_proxy_wrapper
-args=--stdout {{MFMODULE_RUNTIME_HOME}}/log/directory_observer.log --stderr STDOUT -- python3 -m directory_observer.directory_observer --config={{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/directory_observer.ini
+args=--stdout directory_observer.log --stderr STDOUT -- python3 -m directory_observer.directory_observer --config={{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/directory_observer.ini
 numprocesses = 1
 copy_env = True
 autostart = True
@@ -60,7 +60,7 @@ working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 {% if MFDATA_ADMIN_HOSTNAME != "null" %}
 [watcher:telegraf_collector_var_in_files_count]
 cmd=log_proxy_wrapper
-args=--stdout {{MFMODULE_RUNTIME_HOME}}/log/telegraf_collector_var_in_files_count.log --stderr STDOUT -- {{MFDATA_HOME}}/bin/telegraf_collector_var_in_files_count.py
+args=--stdout telegraf_collector_var_in_files_count.log --stderr STDOUT -- {{MFDATA_HOME}}/bin/telegraf_collector_var_in_files_count.py
 numprocesses = 1
 copy_env = True
 autostart = True

--- a/config/crontab.custom
+++ b/config/crontab.custom
@@ -3,6 +3,6 @@
 {% block custom %}
 {% raw %}
 # Garbage collector (files)
-* * * * * {{MFMODULE_HOME}}/bin/cronwrap.sh --lock --timeout=600 --low --random-sleep=10 --log-capture-to={{MFMODULE_RUNTIME_HOME}}/log/garbage_collector.log -- garbage_collector.sh
+* * * * * {{MFMODULE_HOME}}/bin/cronwrap.sh --lock --timeout=600 --low --random-sleep=10 --log-capture-to=garbage_collector.log -- garbage_collector.sh
 {% endraw %}
 {% endblock %}

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -23,7 +23,7 @@ http {
     default_type  text/plain;
     # FIXME: ugly hack with ~~~1 and ~~~~2 to circumvent nginxfmt problem with JSON
     log_format main '~~~1 "@timestamp": "$time_iso8601", "from": "$remote_addr", "method": "$request_method", "uri": "$request_uri", "duration": $request_time, "status": $status, "request_length": $request_length, "reply_length": $bytes_sent ~~~2';
-    access_log  nginx_access.log  main;
+    access_log /dev/stdout main;
     {% if MFDATA_NGINX_LOGGING == "1" %}
         {% if MFDATA_ADMIN_HOSTNAME != "null" %}
             {% if MFDATA_ADMIN_SEND_NGINX_LOGS == "1" %}

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -23,7 +23,7 @@ http {
     default_type  text/plain;
     # FIXME: ugly hack with ~~~1 and ~~~~2 to circumvent nginxfmt problem with JSON
     log_format main '~~~1 "@timestamp": "$time_iso8601", "from": "$remote_addr", "method": "$request_method", "uri": "$request_uri", "duration": $request_time, "status": $status, "request_length": $request_length, "reply_length": $bytes_sent ~~~2';
-    access_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_access.log  main;
+    access_log  nginx_access.log  main;
     {% if MFDATA_NGINX_LOGGING == "1" %}
         {% if MFDATA_ADMIN_HOSTNAME != "null" %}
             {% if MFDATA_ADMIN_SEND_NGINX_LOGS == "1" %}

--- a/doc/mfdata_miscellaneous.md
+++ b/doc/mfdata_miscellaneous.md
@@ -560,7 +560,7 @@ If you need to execute your `cron` command in the Metwork context, you should us
 {% raw %}
 {{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFDATA_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >{{MFMODULE_RUNTIME_HOME}}/log/[your_log_filename] 2>&1
+{{MFDATA_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >[your_log_filename] 2>&1
 {% endraw %}
 ```
 

--- a/doc/mfdata_miscellaneous.md
+++ b/doc/mfdata_miscellaneous.md
@@ -560,7 +560,7 @@ If you need to execute your `cron` command in the Metwork context, you should us
 {% raw %}
 {{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFDATA_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] --log-capture-to [your_log_filename] 2>&1
+{{MFDATA_HOME}}/bin/cronwrap.sh --log-capture-to [your_log_filename] -- plugin_wrapper [your_plugin_name]  [your_sh_command]
 {% endraw %}
 ```
 

--- a/doc/mfdata_miscellaneous.md
+++ b/doc/mfdata_miscellaneous.md
@@ -560,7 +560,7 @@ If you need to execute your `cron` command in the Metwork context, you should us
 {% raw %}
 {{MFDATA_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFDATA_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >[your_log_filename] 2>&1
+{{MFDATA_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] --log-capture-to [your_log_filename] 2>&1
 {% endraw %}
 ```
 


### PR DESCRIPTION
…IRECTORY env variable is used by default)

(mfdata part of metwork-framework/resources#54)