### PR TITLE
Revert "build: fix jinja2 syntax"

### DIFF
--- a/config/config.ini.custom
+++ b/config/config.ini.custom
@@ -24,8 +24,8 @@ other_max_lifetime=360
 ##### CIRCUS #####
 ##################
 [circus]
-endpoint = ipc://{{MFMODULE_RUNTIME_HOME}}var/circus.socket
-pubsub_endpoint = ipc://{{MFMODULE_RUNTIME_HOME}}var/circus_pubsub.socket
+endpoint = ipc://@@@MFMODULE_RUNTIME_HOME@@@/var/circus.socket
+pubsub_endpoint = ipc://@@@MFMODULE_RUNTIME_HOME@@@/var/circus_pubsub.socket
 
 
 ##############################
@@ -58,8 +58,8 @@ flag=1
 # nginx will listen on a unix socket
 # but, if you set a value != 0 bellow, it will also listen this tcp port
 port=9091
-upload_dir={{MFMODULE_RUNTIME_HOME}}var/in/incoming
-clientbody_temp_path={{MFMODULE_RUNTIME_HOME}}var/in/tmp/nginx
+upload_dir=@@@MFMODULE_RUNTIME_HOME@@@/var/in/incoming
+clientbody_temp_path=@@@MFMODULE_RUNTIME_HOME@@@/var/in/tmp/nginx
 # MB
 upload_max_body_size=100
 workers={{MFHARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}}


### PR DESCRIPTION
This reverts commit 81c863136f5be44bc43b18c7f37679ab7794db1d.